### PR TITLE
feat: add Rickydata graph KFDB builders

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,8 +103,14 @@ export {
   buildClaudeCodeHookTraceOperations,
   createClaudeCodeHookTraceFixture,
   buildCodexHookTraceOperations,
+  buildRickydataGraphWriteRequest,
+  canonicalizeRickydataRepoRef,
+  deriveRickydataGraphEdgeId,
+  deriveRickydataGraphId,
   createCodexHookTraceFixture,
   kfdbValue,
+  rickydataGraphContract,
+  rickydataGraphValue,
 } from './kfdb/index.js';
 export type {
   AgentChatTraceEvent,

--- a/packages/core/src/kfdb/client.ts
+++ b/packages/core/src/kfdb/client.ts
@@ -37,6 +37,7 @@ import { deriveKeyFromSignature, encryptProperties, decryptResponseRows } from '
 import { buildAgentChatTraceOperations, type AgentChatTurnTrace } from './agent-chat-trace.js';
 import { buildClaudeCodeHookTraceOperations, type ClaudeCodeHookTrace } from './claude-code-hook-trace.js';
 import { buildCodexHookTraceOperations, type CodexHookTrace } from './codex-hook-trace.js';
+import { buildRickydataGraphWriteRequest, type RickydataGraphWriteInput } from './rickydata-graph.js';
 
 function normalizeKfdbExpiresAt(raw: number): number {
   return raw < 10_000_000_000 ? raw * 1000 : raw;
@@ -287,6 +288,10 @@ export class KFDBClient {
       body: JSON.stringify(payload),
     });
     return this.parseJson<KfdbWriteResponse>(res, 'write');
+  }
+
+  async writeRickydataGraph(input: RickydataGraphWriteInput): Promise<KfdbWriteResponse> {
+    return this.write(buildRickydataGraphWriteRequest(input));
   }
 
   async queryKql(query: string, options: KfdbQueryOptions = {}): Promise<KfdbQueryResponse> {

--- a/packages/core/src/kfdb/index.ts
+++ b/packages/core/src/kfdb/index.ts
@@ -3,6 +3,18 @@ export { MemoryDeriveSessionStore, FileDeriveSessionStore } from './derive-sessi
 export { buildAgentChatTraceOperations, createAgentChatTraceFixture } from './agent-chat-trace.js';
 export { buildClaudeCodeHookTraceOperations, createClaudeCodeHookTraceFixture } from './claude-code-hook-trace.js';
 export { buildCodexHookTraceOperations, createCodexHookTraceFixture } from './codex-hook-trace.js';
+export {
+  GraphEdgeType,
+  GraphEntityKind,
+  RICKYDATA_GRAPH_NAMESPACE,
+  RICKYDATA_GRAPH_SCHEMA_VERSION,
+  buildRickydataGraphWriteRequest,
+  canonicalizeRickydataRepoRef,
+  deriveRickydataGraphEdgeId,
+  deriveRickydataGraphId,
+  rickydataGraphContract,
+  rickydataGraphValue,
+} from './rickydata-graph.js';
 export { kfdbValue } from './values.js';
 export {
   generateSharingKeyPair,
@@ -19,6 +31,15 @@ export type { SharingKeyPair, WrappedGroupKey } from '../encryption.js';
 export type { AgentChatTraceEvent, AgentChatTurnTrace } from './agent-chat-trace.js';
 export type { ClaudeCodeHookEventRecord, ClaudeCodeHookTrace } from './claude-code-hook-trace.js';
 export type { CodexHookEventRecord, CodexHookTrace } from './codex-hook-trace.js';
+export type {
+  RickydataGraphContract,
+  RickydataGraphEdge,
+  RickydataGraphNode,
+  RickydataGraphPrimitiveValue,
+  RickydataGraphWriteInput,
+  RickydataGraphWriteOperation,
+  RickydataGraphWriteRequest,
+} from './rickydata-graph.js';
 
 export type {
   AutoDeriveOptions,

--- a/packages/core/src/kfdb/rickydata-graph.ts
+++ b/packages/core/src/kfdb/rickydata-graph.ts
@@ -1,0 +1,253 @@
+import { createHash } from 'node:crypto';
+
+export const RICKYDATA_GRAPH_NAMESPACE = '2f3e8ab8-8684-5c6a-9fd2-c5467b94251d';
+export const RICKYDATA_GRAPH_SCHEMA_VERSION = 'rickydata.repo_execution_graph.v1';
+
+export enum GraphEntityKind {
+  Repository = 'Repository',
+  Commit = 'Commit',
+  File = 'File',
+  Function = 'Function',
+  TypeDefinition = 'TypeDefinition',
+  TestCase = 'TestCase',
+  Symbol = 'Symbol',
+  Dependency = 'Dependency',
+  GitHubIssue = 'GitHubIssue',
+  GitHubProjectItem = 'GitHubProjectItem',
+  GitHubPullRequest = 'GitHubPullRequest',
+  RickydataWorkIntent = 'RickydataWorkIntent',
+  RickydataAttempt = 'RickydataAttempt',
+  RickydataRun = 'RickydataRun',
+  RickydataPatch = 'RickydataPatch',
+  RickydataProof = 'RickydataProof',
+  CIJob = 'CIJob',
+  AgentSession = 'AgentSession',
+  AgentTraceEvent = 'AgentTraceEvent',
+  RelaySnapshot = 'RelaySnapshot',
+  KfdbProjection = 'KfdbProjection',
+  UnderstandingSummary = 'UnderstandingSummary',
+  CodeConcept = 'CodeConcept',
+  DesignDecision = 'DesignDecision',
+}
+
+export enum GraphEdgeType {
+  Contains = 'CONTAINS',
+  HasCommit = 'HAS_COMMIT',
+  Defines = 'DEFINES',
+  Imports = 'IMPORTS',
+  Calls = 'CALLS',
+  Tests = 'TESTS',
+  DependsOn = 'DEPENDS_ON',
+  Touches = 'TOUCHES',
+  Mentions = 'MENTIONS',
+  Implements = 'IMPLEMENTS',
+  DerivedFromIssue = 'DERIVED_FROM_ISSUE',
+  ProducedBy = 'PRODUCED_BY',
+  Proves = 'PROVES',
+  FailedBy = 'FAILED_BY',
+  Supersedes = 'SUPERSEDES',
+  Blocks = 'BLOCKS',
+  Unblocks = 'UNBLOCKS',
+  SupportedBy = 'SUPPORTED_BY',
+  VerifiedBy = 'VERIFIED_BY',
+  ProjectedToKfdb = 'PROJECTED_TO_KFDB',
+  SyncedToRelay = 'SYNCED_TO_RELAY',
+  Summarizes = 'SUMMARIZES',
+}
+
+export type RickydataGraphPrimitiveValue =
+  | { String: string }
+  | { Integer: number }
+  | { Float: number }
+  | { Boolean: boolean }
+  | { Array: RickydataGraphPrimitiveValue[] }
+  | { Object: Record<string, RickydataGraphPrimitiveValue> }
+  | { Null: null };
+
+export interface RickydataGraphContract {
+  schemaVersion: string;
+  nodeLabels: string[];
+  edgeTypes: string[];
+  idConventions: Record<GraphEntityKind, string[]>;
+}
+
+export interface RickydataGraphNode {
+  kind: GraphEntityKind;
+  idParts: Array<string | number>;
+  properties?: Record<string, RickydataGraphPrimitiveValue>;
+}
+
+export interface RickydataGraphEdge {
+  from: string;
+  to: string;
+  edgeType: GraphEdgeType;
+  properties?: Record<string, RickydataGraphPrimitiveValue>;
+}
+
+export interface RickydataGraphWriteInput {
+  nodes?: RickydataGraphNode[];
+  edges?: RickydataGraphEdge[];
+}
+
+export type RickydataGraphWriteOperation =
+  | {
+      operation: 'create_node';
+      id: string;
+      label: string;
+      properties: Record<string, RickydataGraphPrimitiveValue>;
+      mode: 'merge';
+    }
+  | {
+      operation: 'create_edge';
+      id: string;
+      from: string;
+      to: string;
+      edge_type: string;
+      properties: Record<string, RickydataGraphPrimitiveValue>;
+    };
+
+export interface RickydataGraphWriteRequest {
+  operations: RickydataGraphWriteOperation[];
+  skip_embedding: true;
+}
+
+const ENTITY_ID_PARTS: Record<GraphEntityKind, string[]> = {
+  [GraphEntityKind.Repository]: ['canonical_repo_ref'],
+  [GraphEntityKind.Commit]: ['repo_id', 'commit_sha'],
+  [GraphEntityKind.File]: ['repo_id', 'commit_sha', 'path', 'content_hash'],
+  [GraphEntityKind.Function]: ['file_id', 'function_name', 'span_hash'],
+  [GraphEntityKind.TypeDefinition]: ['file_id', 'type_name', 'span_hash'],
+  [GraphEntityKind.TestCase]: ['file_id', 'test_name', 'span_hash'],
+  [GraphEntityKind.Symbol]: ['repo_id', 'commit_sha', 'path', 'symbol_path', 'span_hash'],
+  [GraphEntityKind.Dependency]: ['repo_id', 'commit_sha', 'dependency_name', 'dependency_version'],
+  [GraphEntityKind.GitHubIssue]: ['repo_id', 'issue_number'],
+  [GraphEntityKind.GitHubProjectItem]: ['repo_id', 'project_item_id'],
+  [GraphEntityKind.GitHubPullRequest]: ['repo_id', 'pull_request_number'],
+  [GraphEntityKind.RickydataWorkIntent]: ['repo_id', 'intent_id'],
+  [GraphEntityKind.RickydataAttempt]: ['repo_id', 'attempt_id'],
+  [GraphEntityKind.RickydataRun]: ['repo_id', 'run_id'],
+  [GraphEntityKind.RickydataPatch]: ['repo_id', 'patch_id'],
+  [GraphEntityKind.RickydataProof]: ['repo_id', 'proof_id'],
+  [GraphEntityKind.CIJob]: ['repo_id', 'provider', 'run_id', 'job_id'],
+  [GraphEntityKind.AgentSession]: ['repo_id', 'session_id'],
+  [GraphEntityKind.AgentTraceEvent]: ['repo_id', 'session_id', 'event_id'],
+  [GraphEntityKind.RelaySnapshot]: ['repo_id', 'remote', 'ref_name', 'object_id'],
+  [GraphEntityKind.KfdbProjection]: ['repo_id', 'projection_id'],
+  [GraphEntityKind.UnderstandingSummary]: ['repo_id', 'commit_sha', 'scope', 'summary_hash'],
+  [GraphEntityKind.CodeConcept]: ['repo_id', 'concept_name', 'source_hash'],
+  [GraphEntityKind.DesignDecision]: ['repo_id', 'decision_id'],
+};
+
+export function rickydataGraphContract(): RickydataGraphContract {
+  return {
+    schemaVersion: RICKYDATA_GRAPH_SCHEMA_VERSION,
+    nodeLabels: Object.values(GraphEntityKind),
+    edgeTypes: Object.values(GraphEdgeType),
+    idConventions: { ...ENTITY_ID_PARTS },
+  };
+}
+
+export function canonicalizeRickydataRepoRef(repoRef: string): string {
+  const trimmed = repoRef.trim();
+  let normalized: string;
+  if (trimmed.startsWith('git@github.com:')) {
+    normalized = `github.com/${trimmed.slice('git@github.com:'.length)}`;
+  } else if (trimmed.startsWith('https://')) {
+    normalized = trimmed.slice('https://'.length);
+  } else if (trimmed.startsWith('http://')) {
+    normalized = trimmed.slice('http://'.length);
+  } else {
+    normalized = trimmed;
+  }
+  return normalized.replace(/\/+$/, '').replace(/\.git$/, '').toLowerCase();
+}
+
+export function deriveRickydataGraphId(entity: GraphEntityKind, parts: Array<string | number>): string {
+  const expected = ENTITY_ID_PARTS[entity];
+  if (!expected) throw new Error(`Unsupported Rickydata graph entity kind: ${entity}`);
+  if (parts.length !== expected.length) {
+    throw new Error(`${entity} expected ${expected.length} parts (${expected.join(', ')}) but received ${parts.length}`);
+  }
+  const normalizedParts = parts.map((part, idx) => {
+    const normalized = String(part).trim();
+    if (normalized.length === 0) {
+      throw new Error(`${entity} id part '${expected[idx]}' at position ${idx} must not be empty`);
+    }
+    return normalized;
+  });
+  return uuidV5(
+    `${RICKYDATA_GRAPH_SCHEMA_VERSION}:${[entity, ...normalizedParts].join('\u001f')}`,
+    RICKYDATA_GRAPH_NAMESPACE,
+  );
+}
+
+export function deriveRickydataGraphEdgeId(from: string, edgeType: GraphEdgeType, to: string): string {
+  const normalizedFrom = from.trim();
+  const normalizedTo = to.trim();
+  if (!normalizedFrom || !normalizedTo) throw new Error('edge endpoints must not be empty');
+  return uuidV5(
+    `${RICKYDATA_GRAPH_SCHEMA_VERSION}:edge:${normalizedFrom}\u001f${edgeType}\u001f${normalizedTo}`,
+    RICKYDATA_GRAPH_NAMESPACE,
+  );
+}
+
+export function rickydataGraphValue(input: unknown): RickydataGraphPrimitiveValue {
+  if (input === null || input === undefined) return { Null: null };
+  if (typeof input === 'boolean') return { Boolean: input };
+  if (typeof input === 'number') return Number.isInteger(input) ? { Integer: input } : { Float: input };
+  if (Array.isArray(input)) return { Array: input.map(rickydataGraphValue) };
+  if (typeof input === 'object') {
+    return {
+      Object: Object.fromEntries(
+        Object.entries(input as Record<string, unknown>).map(([key, value]) => [key, rickydataGraphValue(value)]),
+      ),
+    };
+  }
+  return { String: String(input) };
+}
+
+export function buildRickydataGraphWriteRequest(input: RickydataGraphWriteInput): RickydataGraphWriteRequest {
+  const operations: RickydataGraphWriteOperation[] = [];
+
+  for (const node of input.nodes ?? []) {
+    const id = deriveRickydataGraphId(node.kind, node.idParts);
+    operations.push({
+      operation: 'create_node',
+      id,
+      label: node.kind,
+      properties: {
+        ...(node.properties ?? {}),
+        rickydata_graph_schema_version: { String: RICKYDATA_GRAPH_SCHEMA_VERSION },
+        rickydata_graph_kind: { String: node.kind },
+        rickydata_graph_id_parts: { Array: node.idParts.map((part) => ({ String: String(part) })) },
+      },
+      mode: 'merge',
+    });
+  }
+
+  for (const edge of input.edges ?? []) {
+    operations.push({
+      operation: 'create_edge',
+      id: deriveRickydataGraphEdgeId(edge.from, edge.edgeType, edge.to),
+      from: edge.from,
+      to: edge.to,
+      edge_type: edge.edgeType,
+      properties: {
+        ...(edge.properties ?? {}),
+        rickydata_graph_schema_version: { String: RICKYDATA_GRAPH_SCHEMA_VERSION },
+      },
+    });
+  }
+
+  return { operations, skip_embedding: true };
+}
+
+function uuidV5(name: string, namespace: string): string {
+  const ns = Buffer.from(namespace.replace(/-/g, ''), 'hex');
+  if (ns.length !== 16) throw new Error('Invalid UUID namespace');
+  const hash = createHash('sha1').update(Buffer.concat([ns, Buffer.from(name)])).digest();
+  hash[6] = (hash[6] & 0x0f) | 0x50;
+  hash[8] = (hash[8] & 0x3f) | 0x80;
+  const hex = hash.subarray(0, 16).toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}

--- a/packages/core/tests/rickydata-graph.test.ts
+++ b/packages/core/tests/rickydata-graph.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import { KFDBClient } from '../src/kfdb/client.js';
+import {
+  GraphEdgeType,
+  GraphEntityKind,
+  canonicalizeRickydataRepoRef,
+  deriveRickydataGraphEdgeId,
+  deriveRickydataGraphId,
+  rickydataGraphContract,
+  rickydataGraphValue,
+  buildRickydataGraphWriteRequest,
+} from '../src/kfdb/index.js';
+
+const BASE = 'http://localhost:8080';
+
+function mockJsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+describe('Rickydata repo/execution graph SDK helpers', () => {
+  it('exports the KFDB graph contract from the core schema', () => {
+    const contract = rickydataGraphContract();
+
+    expect(contract.schemaVersion).toBe('rickydata.repo_execution_graph.v1');
+    expect(contract.nodeLabels).toContain('Repository');
+    expect(contract.nodeLabels).toContain('RickydataRun');
+    expect(contract.nodeLabels).toContain('GitHubIssue');
+    expect(contract.edgeTypes).toContain('PROVES');
+    expect(contract.edgeTypes).toContain('PROJECTED_TO_KFDB');
+    expect(contract.idConventions.Repository).toEqual(['canonical_repo_ref']);
+    expect(contract.idConventions.File).toEqual(['repo_id', 'commit_sha', 'path', 'content_hash']);
+  });
+
+  it('canonicalizes repo refs and derives UUIDv5 IDs compatible with kfdb-core', () => {
+    const canonicalRepo = canonicalizeRickydataRepoRef('git@github.com:RickyCambrian/knowledgeflow_db.git');
+    const repoId = deriveRickydataGraphId(GraphEntityKind.Repository, [canonicalRepo]);
+    const fileId = deriveRickydataGraphId(GraphEntityKind.File, [repoId, 'abc123', 'src/lib.rs', 'sha256:content']);
+
+    expect(canonicalRepo).toBe('github.com/rickycambrian/knowledgeflow_db');
+    expect(repoId).toBe('2cdf7ea4-533c-59da-987f-392e6c6996b9');
+    expect(fileId).toBe('f45b0284-044c-5ef3-af2f-932f0b7d984a');
+    expect(() => deriveRickydataGraphId(GraphEntityKind.File, [repoId, 'abc123', 'src/lib.rs'])).toThrow(
+      /expected 4 parts/,
+    );
+  });
+
+  it('builds idempotent /api/v1/write operations for graph nodes and edges', () => {
+    const canonicalRepo = canonicalizeRickydataRepoRef('https://github.com/rickycambrian/knowledgeflow_db.git');
+    const repoId = deriveRickydataGraphId(GraphEntityKind.Repository, [canonicalRepo]);
+    const runId = deriveRickydataGraphId(GraphEntityKind.RickydataRun, [repoId, 'run-1']);
+    const proofId = deriveRickydataGraphId(GraphEntityKind.RickydataProof, [repoId, 'proof-1']);
+    const edgeId = deriveRickydataGraphEdgeId(runId, GraphEdgeType.Proves, proofId);
+
+    const request = buildRickydataGraphWriteRequest({
+      nodes: [
+        {
+          kind: GraphEntityKind.Repository,
+          idParts: [canonicalRepo],
+          properties: { name: rickydataGraphValue('knowledgeflow_db') },
+        },
+        {
+          kind: GraphEntityKind.RickydataRun,
+          idParts: [repoId, 'run-1'],
+          properties: { status: rickydataGraphValue('passed') },
+        },
+        {
+          kind: GraphEntityKind.RickydataProof,
+          idParts: [repoId, 'proof-1'],
+          properties: { proof_kind: rickydataGraphValue('test') },
+        },
+      ],
+      edges: [{ from: runId, to: proofId, edgeType: GraphEdgeType.Proves }],
+    });
+
+    expect(runId).toBe('d600dc2d-b5ef-55b8-8de4-ce6341791dad');
+    expect(proofId).toBe('5b23e840-f52a-544d-8c3e-fc1faeb01417');
+    expect(edgeId).toBe('c58425e8-2b45-58e3-90fb-1510e245498c');
+    expect(request.skip_embedding).toBe(true);
+    expect(request.operations).toHaveLength(4);
+    expect(request.operations[0]).toMatchObject({
+      operation: 'create_node',
+      id: repoId,
+      label: 'Repository',
+      mode: 'merge',
+      properties: {
+        name: { String: 'knowledgeflow_db' },
+        rickydata_graph_schema_version: { String: 'rickydata.repo_execution_graph.v1' },
+        rickydata_graph_kind: { String: 'Repository' },
+      },
+    });
+    expect(request.operations[3]).toMatchObject({
+      operation: 'create_edge',
+      id: edgeId,
+      from: runId,
+      to: proofId,
+      edge_type: 'PROVES',
+    });
+  });
+
+  it('writes graph projections through KFDBClient.writeRickydataGraph', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      mockJsonResponse({ operations_executed: 2, execution_time_ms: 3, affected_ids: ['node-1', 'edge-1'] }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+
+    const repoRef = canonicalizeRickydataRepoRef('https://github.com/rickycambrian/rickydata_SDK.git');
+    const repoId = deriveRickydataGraphId(GraphEntityKind.Repository, [repoRef]);
+    const issueId = deriveRickydataGraphId(GraphEntityKind.GitHubIssue, [repoId, '7']);
+    const client = new KFDBClient({ baseUrl: BASE, token: 'tok_123' });
+
+    await client.writeRickydataGraph({
+      nodes: [
+        { kind: GraphEntityKind.Repository, idParts: [repoRef] },
+        { kind: GraphEntityKind.GitHubIssue, idParts: [repoId, '7'] },
+      ],
+      edges: [{ from: issueId, to: repoId, edgeType: GraphEdgeType.SupportedBy }],
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/api/v1/write`);
+    const body = JSON.parse(String((fetchMock.mock.calls[0][1] as RequestInit).body));
+    expect(body.skip_embedding).toBe(true);
+    expect(body.operations.map((op: { operation: string }) => op.operation)).toEqual([
+      'create_node',
+      'create_node',
+      'create_edge',
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- add a TypeScript Rickydata repo/execution graph contract matching the KFDB core vocabulary
- add deterministic UUIDv5 node/edge ID derivation, repo canonicalization, primitive value conversion, and KFDB write request builders
- expose `KFDBClient.writeRickydataGraph(...)` plus public package exports for SDK consumers

## Evidence
- `npm run build` in `packages/core` passed
- `npm test` in `packages/core` passed: 58 test files, 813 passed, 10 skipped
- root workspace `npm run build:core` passed
- root workspace `npm test -- --filter=rickydata` passed: 58 test files, 813 passed, 10 skipped

Closes #7
