### PR TITLE
fix(agent-client): Claude OAuth bundle under `credentials` key (gateway contract)

### DIFF
--- a/packages/core/src/agent/agent-builder.ts
+++ b/packages/core/src/agent/agent-builder.ts
@@ -1,0 +1,528 @@
+/**
+ * Agent Builder
+ *
+ * Reusable engine for creating and provisioning custom agents on the
+ * RickyData agent gateway (https://agents.rickydata.org). Wraps the create-flow
+ * documented in the create-flow contract:
+ *
+ *   create (POST /agents/custom) → skills → claude-md → agent-secrets →
+ *   mcp-secrets → kb-tools/reflect → verify → chat probe
+ *
+ * The builder reuses {@link AgentClient} for everything it already implements
+ * (upsert, secrets, reflect/kb-tools, chat) and {@link AgentMCPClient} for the
+ * MCP `tools/list` verification. The two endpoints AgentClient does not expose —
+ * `PUT /wallet/skills/{name}` and `PUT /wallet/claude-md/{id}` — are issued
+ * directly here using the same bearer token.
+ *
+ * Auth: the agent gateway uses `GET /auth/challenge` + `POST /auth/verify` (NOT
+ * the `/api/auth/token-message` path that `createWalletToken` targets, which 404s
+ * on agents.rickydata.org). Pass a cached `mcpwt_` token or a private key and the
+ * builder / AgentClient handles the challenge-verify flow.
+ */
+
+import * as fs from 'fs/promises';
+import type { Dirent } from 'fs';
+import * as path from 'path';
+import { AgentClient } from './agent-client.js';
+import { AgentMCPClient } from './agent-mcp-client.js';
+import { parseAgentMarkdown } from './recipe.js';
+import type {
+  AgentSpec,
+  AgentRecipe,
+  CreateResult,
+  CustomAgentDefinition,
+  SkillFile,
+  VerifyResult,
+} from './types.js';
+
+const DEFAULT_GATEWAY_URL = 'https://agents.rickydata.org';
+
+export interface AgentBuilderConfig {
+  /** Pre-existing `mcpwt_` wallet token (interchangeable across gateways). */
+  token?: string;
+  /** Private key for wallet auth (0x-prefixed hex). Used if no token. */
+  privateKey?: string;
+  /** Agent gateway URL. Defaults to https://agents.rickydata.org */
+  gatewayUrl?: string;
+  /** Inject a pre-built AgentClient (mainly for testing). */
+  client?: AgentClient;
+}
+
+export interface DeployRecipeOptions {
+  /** Secret values to set, keyed by name (recipe carries names only). */
+  secrets?: Record<string, string>;
+  /** MCP-server secrets, keyed by serverId → { NAME: value }. */
+  mcpSecrets?: Record<string, Record<string, string>>;
+  /** Per-agent KFDB token (POST /agents/custom/{id}/reflect/kb-token). */
+  kbToken?: string;
+  /** Skip the post-deploy verify step. */
+  skipVerify?: boolean;
+  /** Progress callback for CLI logging. */
+  onStep?: (step: string, detail?: string) => void;
+}
+
+export class AgentBuilder {
+  private readonly client: AgentClient;
+  private readonly gatewayUrl: string;
+  private token?: string;
+  private readonly privateKey?: string;
+
+  constructor(config: AgentBuilderConfig = {}) {
+    if (!config.client && !config.token && !config.privateKey) {
+      throw new Error('AgentBuilder requires a token, privateKey, or a pre-built client');
+    }
+    this.gatewayUrl = (config.gatewayUrl ?? DEFAULT_GATEWAY_URL).replace(/\/$/, '');
+    this.token = config.token;
+    this.privateKey = config.privateKey;
+    this.client = config.client ?? new AgentClient({
+      token: config.token,
+      privateKey: config.privateKey,
+      gatewayUrl: this.gatewayUrl,
+      sessionStorePath: null,
+    });
+  }
+
+  /** The underlying AgentClient (auth, upsert, secrets, reflect, chat). */
+  get agentClient(): AgentClient {
+    return this.client;
+  }
+
+  // ─── Create ───────────────────────────────────────────────
+
+  /**
+   * Map an {@link AgentSpec} to a {@link CustomAgentDefinition}.
+   * `name` becomes the id when none is supplied (the gateway may return a
+   * `-<6hex>`-suffixed id for private agents).
+   */
+  static toDefinition(spec: AgentSpec): CustomAgentDefinition {
+    if (!spec.name) throw new Error('spec.name is required');
+    const metadata: Record<string, unknown> = { ...(spec.metadata ?? {}) };
+    if (spec.agentSecrets?.length) metadata.agent_secrets = spec.agentSecrets;
+    if (spec.skills?.length) metadata.skills = spec.skills;
+    if (spec.visibility) metadata.visibility = spec.visibility;
+    return {
+      id: spec.id ?? spec.name,
+      name: spec.name,
+      ...(spec.title ? { title: spec.title } : {}),
+      ...(spec.description ? { description: spec.description } : {}),
+      ...(spec.model ? { model: spec.model } : {}),
+      ...(spec.category ? { category: spec.category } : {}),
+      ...(spec.mcpServers?.length ? { mcp_servers: spec.mcpServers } : {}),
+      ...(spec.builtinTools?.length ? { builtin_tools: spec.builtinTools } : {}),
+      systemPrompt: spec.systemPrompt,
+      ...(Object.keys(metadata).length ? { metadata } : {}),
+    };
+  }
+
+  /**
+   * Create (or upsert) an agent from a spec. Returns the resolved agent id and
+   * the create-result scaffold (no skills/secrets applied — call the dedicated
+   * methods or {@link deployRecipe} for the full sequence).
+   */
+  async createAgent(spec: AgentSpec): Promise<CreateResult> {
+    const definition = AgentBuilder.toDefinition(spec);
+    const result = await this.client.upsertCustomAgent(definition);
+    return {
+      agentId: result.agentId,
+      agentName: result.agentName,
+      qualityScore: result.qualityScore,
+      uploadedSkills: [],
+      claudeRoutingUploaded: false,
+      agentSecretsSet: [],
+      mcpSecretsSet: [],
+      kbToolsEnabled: false,
+      reflectConfigured: false,
+    };
+  }
+
+  // ─── Skills ───────────────────────────────────────────────
+
+  /**
+   * Upload skill files for an agent. One `PUT /wallet/skills/{name}` per skill
+   * with body `{ content, agentId }`. Returns the uploaded skill names.
+   */
+  async uploadSkills(agentId: string, skills: SkillFile[]): Promise<string[]> {
+    if (!agentId) throw new Error('agentId is required');
+    const uploaded: string[] = [];
+    for (const skill of skills) {
+      const res = await this.fetchWithAuth(
+        `${this.gatewayUrl}/wallet/skills/${encodeURIComponent(skill.name)}`,
+        {
+          method: 'PUT',
+          body: JSON.stringify({ content: skill.content, agentId }),
+        },
+      );
+      if (!res.ok) {
+        const body = await res.text();
+        throw new Error(`Failed to upload skill "${skill.name}": ${res.status} ${body}`);
+      }
+      uploaded.push(skill.name);
+    }
+    return uploaded;
+  }
+
+  /** List the skills the gateway has registered for an agent. */
+  async listSkills(agentId: string): Promise<string[]> {
+    if (!agentId) throw new Error('agentId is required');
+    const res = await this.fetchWithAuth(
+      `${this.gatewayUrl}/wallet/skills/agent/${encodeURIComponent(agentId)}`,
+      { method: 'GET' },
+    );
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Failed to list agent skills: ${res.status} ${body}`);
+    }
+    const data = await res.json() as { skills?: Array<{ name: string }> };
+    return (data.skills ?? []).map((s) => s.name);
+  }
+
+  // ─── CLAUDE routing ───────────────────────────────────────
+
+  /** Upload per-agent CLAUDE routing via `PUT /wallet/claude-md/{id}`. */
+  async uploadClaudeRouting(agentId: string, content: string): Promise<void> {
+    if (!agentId) throw new Error('agentId is required');
+    const res = await this.fetchWithAuth(
+      `${this.gatewayUrl}/wallet/claude-md/${encodeURIComponent(agentId)}`,
+      {
+        method: 'PUT',
+        body: JSON.stringify({ content }),
+      },
+    );
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Failed to upload CLAUDE routing: ${res.status} ${body}`);
+    }
+  }
+
+  // ─── Secrets ──────────────────────────────────────────────
+
+  /** Set agent-level secrets (`POST /wallet/agent-secrets/{id}`). */
+  async setAgentSecrets(agentId: string, secrets: Record<string, string>): Promise<string[]> {
+    if (!agentId) throw new Error('agentId is required');
+    if (!secrets || Object.keys(secrets).length === 0) return [];
+    await this.client.storeAgentSecrets(agentId, secrets);
+    return Object.keys(secrets);
+  }
+
+  /** Set MCP-server secrets (`POST /wallet/mcp-secrets/{serverId}`). */
+  async setMcpSecrets(serverId: string, secrets: Record<string, string>): Promise<void> {
+    if (!serverId) throw new Error('serverId is required');
+    await this.client.storeMcpSecrets(serverId, secrets);
+  }
+
+  // ─── KFDB / KnowledgeBook ─────────────────────────────────
+
+  /** Enable gateway-native KnowledgeBook (KFDB) tools for an agent. */
+  async enableKbTools(agentId: string): Promise<void> {
+    await this.client.setKnowledgeBookTools(agentId, true);
+  }
+
+  /** Set a per-agent KFDB token (flips `kbAuthConfigured` → true). */
+  async setKbToken(agentId: string, kbToken: string): Promise<void> {
+    await this.client.setKnowledgeBookToken(agentId, kbToken);
+  }
+
+  // ─── Verify ───────────────────────────────────────────────
+
+  /**
+   * Verify a provisioned agent end-to-end (read-only): existence, skills, MCP
+   * tools (`tools/list`), MCP requirements, agent-secret status, and kb-tools /
+   * reflect state. Best-effort — individual probes that fail are recorded as
+   * absent rather than throwing.
+   */
+  async verify(agentId: string): Promise<VerifyResult> {
+    if (!agentId) throw new Error('agentId is required');
+    const result: VerifyResult = {
+      agentId,
+      exists: false,
+      skills: [],
+      tools: [],
+    };
+
+    try {
+      await this.client.getCustomAgent(agentId);
+      result.exists = true;
+    } catch {
+      result.exists = false;
+    }
+
+    try {
+      result.skills = await this.listSkills(agentId);
+    } catch { /* leave empty */ }
+
+    try {
+      const mcp = new AgentMCPClient({
+        token: this.token,
+        privateKey: this.privateKey,
+        baseUrl: this.gatewayUrl,
+      });
+      await mcp.connect(agentId);
+      const tools = await mcp.listTools(agentId);
+      result.tools = tools.map((t) => t.name);
+    } catch { /* leave empty */ }
+
+    try {
+      result.mcpRequirements = await this.client.getMcpRequirements(agentId);
+    } catch { /* leave undefined */ }
+
+    try {
+      result.secretStatus = await this.client.getAgentSecretStatus(agentId);
+    } catch { /* leave undefined */ }
+
+    try {
+      const kb = await this.client.getKnowledgeBookTools(agentId);
+      result.kbToolsEnabled = kb.kbToolsEnabled;
+    } catch { /* leave undefined */ }
+
+    try {
+      result.reflect = await this.client.getReflectStatus(agentId);
+    } catch { /* leave undefined */ }
+
+    return result;
+  }
+
+  /** Send a single message to an agent and return its accumulated text response. */
+  async chatProbe(
+    agentId: string,
+    message: string,
+    options?: { model?: string; onToolCall?: (name: string) => void },
+  ): Promise<{ text: string; sessionId: string; toolCalls: string[] }> {
+    const toolCalls: string[] = [];
+    const result = await this.client.chat(agentId, message, {
+      model: options?.model,
+      onToolCall: (tool) => {
+        toolCalls.push(tool.name);
+        options?.onToolCall?.(tool.name);
+      },
+    });
+    return { text: result.text, sessionId: result.sessionId, toolCalls };
+  }
+
+  // ─── Recipe deployment ────────────────────────────────────
+
+  /**
+   * Parse a recipe directory into an {@link AgentRecipe}.
+   *
+   * Layout (both skill conventions are supported):
+   *   <dir>/agent.md                    YAML front-matter + markdown body (→ systemPrompt)
+   *   <dir>/skills/<name>/SKILL.md       skill-per-directory (the convention the notes recipe uses)
+   *   <dir>/skills/<name>.md             OR a flat one-file-per-skill layout
+   *   <dir>/claude-routing.md           optional per-agent CLAUDE routing
+   *
+   * If the agent.md front-matter lists `skills:`, only those skills are loaded
+   * (the skill name resolves to `skills/<name>/SKILL.md`, falling back to
+   * `skills/<name>.md`); otherwise every skill found under `skills/` is loaded.
+   */
+  static async parseRecipe(dir: string): Promise<AgentRecipe> {
+    const agentMdPath = path.join(dir, 'agent.md');
+    let raw: string;
+    try {
+      raw = await fs.readFile(agentMdPath, 'utf8');
+    } catch {
+      throw new Error(`Recipe is missing agent.md at ${agentMdPath}`);
+    }
+    const spec = parseAgentMarkdown(raw);
+
+    const skillsDir = path.join(dir, 'skills');
+    const skills: SkillFile[] = [];
+
+    // Resolve a skill name to its content file, trying both layouts.
+    const loadSkill = async (name: string): Promise<string | null> => {
+      const candidates = [
+        path.join(skillsDir, name, 'SKILL.md'),
+        path.join(skillsDir, `${name}.md`),
+      ];
+      for (const candidate of candidates) {
+        try {
+          return await fs.readFile(candidate, 'utf8');
+        } catch { /* try next */ }
+      }
+      return null;
+    };
+
+    if (spec.skills && spec.skills.length > 0) {
+      for (const name of spec.skills) {
+        const content = await loadSkill(name);
+        if (content === null) {
+          throw new Error(
+            `Recipe declares skill "${name}" but neither skills/${name}/SKILL.md nor skills/${name}.md exists`,
+          );
+        }
+        skills.push({ name, content });
+      }
+    } else {
+      // No explicit list — discover every skill under skills/.
+      let entries: Dirent[] = [];
+      try {
+        entries = await fs.readdir(skillsDir, { withFileTypes: true });
+      } catch { /* no skills dir */ }
+      for (const entry of entries) {
+        if (entry.isDirectory()) {
+          const content = await loadSkill(entry.name);
+          if (content !== null) skills.push({ name: entry.name, content });
+        } else if (entry.isFile() && /\.md$/i.test(entry.name) && entry.name.toLowerCase() !== 'skill.md') {
+          const name = entry.name.replace(/\.md$/i, '');
+          skills.push({ name, content: await fs.readFile(path.join(skillsDir, entry.name), 'utf8') });
+        }
+      }
+    }
+    // Keep the spec's skill list aligned with what we actually loaded.
+    spec.skills = skills.map((s) => s.name);
+
+    let claudeRouting: string | undefined;
+    try {
+      claudeRouting = await fs.readFile(path.join(dir, 'claude-routing.md'), 'utf8');
+    } catch { /* optional */ }
+
+    return { spec, skills, claudeRouting };
+  }
+
+  /**
+   * Deploy a recipe directory end-to-end:
+   *   create → skills → claude-md → agent-secrets → mcp-secrets →
+   *   kb-tools/reflect → verify
+   *
+   * Secret values come from {@link DeployRecipeOptions} (the recipe carries names
+   * only). The resolved agent id from the create call is used for every
+   * subsequent step.
+   */
+  async deployRecipe(dir: string, options: DeployRecipeOptions = {}): Promise<CreateResult> {
+    const step = options.onStep ?? (() => {});
+    const recipe = await AgentBuilder.parseRecipe(dir);
+    return this.deploy(recipe, options, step);
+  }
+
+  /** Deploy an already-parsed recipe. Shared by {@link deployRecipe}. */
+  async deploy(
+    recipe: AgentRecipe,
+    options: DeployRecipeOptions = {},
+    step: (s: string, detail?: string) => void = () => {},
+  ): Promise<CreateResult> {
+    const { spec, skills, claudeRouting } = recipe;
+
+    step('create', spec.name);
+    const created = await this.createAgent(spec);
+    const agentId = created.agentId;
+    step('created', agentId);
+
+    if (skills.length > 0) {
+      step('skills', `${skills.length} skill(s)`);
+      created.uploadedSkills = await this.uploadSkills(agentId, skills);
+    }
+
+    if (claudeRouting) {
+      step('claude-md');
+      await this.uploadClaudeRouting(agentId, claudeRouting);
+      created.claudeRoutingUploaded = true;
+    }
+
+    if (options.secrets && Object.keys(options.secrets).length > 0) {
+      step('agent-secrets', Object.keys(options.secrets).join(', '));
+      created.agentSecretsSet = await this.setAgentSecrets(agentId, options.secrets);
+    }
+
+    if (options.mcpSecrets) {
+      for (const [serverId, secrets] of Object.entries(options.mcpSecrets)) {
+        if (!secrets || Object.keys(secrets).length === 0) continue;
+        step('mcp-secrets', serverId);
+        await this.setMcpSecrets(serverId, secrets);
+        created.mcpSecretsSet.push(serverId);
+      }
+    }
+
+    if (spec.kbTools) {
+      step('kb-tools');
+      await this.enableKbTools(agentId);
+      created.kbToolsEnabled = true;
+    }
+
+    if (options.kbToken) {
+      step('kb-token');
+      await this.setKbToken(agentId, options.kbToken);
+    }
+
+    if (spec.reflect && (spec.reflect.enabled !== undefined || spec.reflect.config)) {
+      step('reflect');
+      await this.client.updateReflectConfig(agentId, spec.reflect);
+      created.reflectConfigured = true;
+    }
+
+    if (!options.skipVerify) {
+      step('verify');
+      await this.verify(agentId);
+    }
+
+    return created;
+  }
+
+  // ─── Internal ─────────────────────────────────────────────
+
+  /**
+   * fetch with the gateway bearer token attached. Reuses the AgentClient's auth
+   * (it resolves a token from a cached `mcpwt_` token or via challenge/verify),
+   * which keeps the skills/claude-md PUTs on the same auth path as everything else.
+   */
+  private async fetchWithAuth(url: string, init: RequestInit): Promise<Response> {
+    const token = await this.resolveToken();
+    return fetch(url, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${token}`,
+        ...(init.headers ?? {}),
+      },
+    });
+  }
+
+  /**
+   * Resolve a bearer token for the skills/claude-md PUTs (which AgentClient does
+   * not wrap). Prefers a supplied/cached `mcpwt_` token; otherwise runs the agent
+   * gateway's challenge/verify flow with the configured private key. The token is
+   * cached for subsequent calls.
+   */
+  private async resolveToken(): Promise<string> {
+    if (this.token) return this.token;
+    if (this.privateKey) {
+      this.token = await challengeVerifyToken(this.gatewayUrl, this.privateKey);
+      return this.token;
+    }
+    throw new Error(
+      'No bearer token available. Construct AgentBuilder with a token, or with a privateKey ' +
+        'so the builder can run the challenge/verify flow before skill/claude-md uploads.',
+    );
+  }
+}
+
+/**
+ * Mint a wallet token against the AGENT gateway via `GET /auth/challenge` +
+ * `POST /auth/verify`. This is the path that works on agents.rickydata.org
+ * (the `/api/auth/token-message` path used by `createWalletToken` 404s there).
+ */
+export async function challengeVerifyToken(
+  gatewayUrl: string,
+  privateKey: string,
+): Promise<string> {
+  const base = gatewayUrl.replace(/\/$/, '');
+  const key = (privateKey.startsWith('0x') ? privateKey : `0x${privateKey}`) as `0x${string}`;
+  const { privateKeyToAccount } = await import('viem/accounts');
+  const account = privateKeyToAccount(key);
+
+  const challengeRes = await fetch(`${base}/auth/challenge`);
+  if (!challengeRes.ok) {
+    throw new Error(`Auth challenge failed: ${challengeRes.status}`);
+  }
+  const { nonce, message } = await challengeRes.json() as { nonce: string; message: string };
+  const signature = await account.signMessage({ message });
+
+  const verifyRes = await fetch(`${base}/auth/verify`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ walletAddress: account.address, signature, nonce }),
+  });
+  if (!verifyRes.ok) {
+    const body = await verifyRes.text();
+    throw new Error(`Auth verification failed: ${verifyRes.status} ${body}`);
+  }
+  const { token } = await verifyRes.json() as { token: string };
+  return token;
+}

--- a/packages/core/src/agent/agent-client.ts
+++ b/packages/core/src/agent/agent-client.ts
@@ -50,6 +50,8 @@ import type {
   FreeTierStatus,
   TeamExecutionEngine,
   CodexAuthStatus,
+  AnthropicOAuthStatus,
+  AnthropicOAuthBundle,
   MarketplaceProvider,
   ProviderApiKeyStatus,
   ProviderVaultUnlockResult,
@@ -376,6 +378,80 @@ export class AgentClient {
     if (!res.ok) {
       const body = await res.text();
       throw new Error(`Failed to get Codex auth signing challenge: ${res.status} ${body}`);
+    }
+    return res.json();
+  }
+
+  // ─── Anthropic (Claude Code) OAuth Subscription Auth ─────────
+
+  /** Get wallet Anthropic OAuth (Claude Code subscription) credential status. */
+  async getAnthropicOAuthStatus(): Promise<AnthropicOAuthStatus> {
+    await this.ensureAuthenticated();
+    const res = await fetch(`${this.gatewayUrl}/wallet/anthropic-oauth/status`, {
+      headers: this.authHeaders(),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Failed to get Anthropic OAuth status: ${res.status} ${body}`);
+    }
+    return res.json();
+  }
+
+  /**
+   * Upload an Anthropic OAuth credential bundle for subscription-backed Claude execution.
+   * The bundle is encrypted at the gateway under a wallet-derived key; the request is
+   * authorized by a wallet signature. Token material is sent only in this signed call.
+   */
+  async setAnthropicOAuth(bundle: AnthropicOAuthBundle): Promise<AnthropicOAuthStatus> {
+    await this.ensureAuthenticated();
+    const { message, nonce } = await this.getAnthropicOAuthDeriveChallenge();
+    const signature = await this.signWithPrivateKey(message, 'Anthropic OAuth sync requires the owner wallet private key');
+    const res = await fetch(`${this.gatewayUrl}/wallet/anthropic-oauth`, {
+      method: 'PUT',
+      headers: this.authHeaders(),
+      body: JSON.stringify({ bundle, signature, nonce }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Failed to set Anthropic OAuth: ${res.status} ${body}`);
+    }
+    return res.json();
+  }
+
+  /** Unlock encrypted Anthropic OAuth credential for this gateway session. */
+  async unlockAnthropicOAuth(): Promise<AnthropicOAuthStatus> {
+    await this.ensureAuthenticated();
+    const { message } = await this.getAnthropicOAuthDeriveChallenge();
+    const signature = await this.signWithPrivateKey(message, 'Anthropic OAuth unlock requires the owner wallet private key');
+    const res = await fetch(`${this.gatewayUrl}/wallet/anthropic-oauth/unlock`, {
+      method: 'POST',
+      headers: this.authHeaders(),
+      body: JSON.stringify({ signature }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Failed to unlock Anthropic OAuth: ${res.status} ${body}`);
+    }
+    return res.json();
+  }
+
+  /** Delete wallet Anthropic OAuth credential. */
+  async deleteAnthropicOAuth(): Promise<void> {
+    await this.ensureAuthenticated();
+    const res = await fetch(`${this.gatewayUrl}/wallet/anthropic-oauth`, {
+      method: 'DELETE',
+      headers: this.authHeaders(),
+    });
+    if (!res.ok) throw new Error(`Failed to delete Anthropic OAuth: ${res.status}`);
+  }
+
+  private async getAnthropicOAuthDeriveChallenge(): Promise<{ message: string; nonce: string }> {
+    const res = await fetch(`${this.gatewayUrl}/wallet/anthropic-oauth/derive-challenge`, {
+      headers: this.authHeaders(),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`Failed to get Anthropic OAuth signing challenge: ${res.status} ${body}`);
     }
     return res.json();
   }

--- a/packages/core/src/agent/agent-client.ts
+++ b/packages/core/src/agent/agent-client.ts
@@ -406,10 +406,14 @@ export class AgentClient {
     await this.ensureAuthenticated();
     const { message, nonce } = await this.getAnthropicOAuthDeriveChallenge();
     const signature = await this.signWithPrivateKey(message, 'Anthropic OAuth sync requires the owner wallet private key');
+    // The deployed gateway reads the bundle from `credentials` (its PUT handler
+    // does `req.body?.credentials ?? req.body?.claudeAiOauth ?? req.body`). Sending
+    // it under a `bundle` key falls through to the whole body and fails validation,
+    // so the SHARED CONTRACT key here is `credentials` (carrying the claudeAiOauth wrapper).
     const res = await fetch(`${this.gatewayUrl}/wallet/anthropic-oauth`, {
       method: 'PUT',
       headers: this.authHeaders(),
-      body: JSON.stringify({ bundle, signature, nonce }),
+      body: JSON.stringify({ credentials: bundle, signature, nonce }),
     });
     if (!res.ok) {
       const body = await res.text();

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -80,6 +80,8 @@ export type {
   McpRequirementsResponse,
   AgentSecretStatus,
   CodexAuthStatus,
+  AnthropicOAuthStatus,
+  AnthropicOAuthBundle,
 
   // Wallet
   WalletSettings,

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,6 +1,15 @@
 export { AgentClient } from './agent-client.js';
 export { AgentMCPClient } from './agent-mcp-client.js';
 export { AgentSession } from './agent-session.js';
+export { AgentBuilder, challengeVerifyToken } from './agent-builder.js';
+export type { AgentBuilderConfig, DeployRecipeOptions } from './agent-builder.js';
+export {
+  parseAgentMarkdown,
+  splitFrontMatter,
+  parseFrontMatterBlock,
+  toStringList,
+} from './recipe.js';
+export type { ParsedFrontMatter } from './recipe.js';
 // SessionStore uses Node.js builtins (fs, path, os) — export from a
 // separate entrypoint to avoid breaking browser bundlers.
 // import { SessionStore } from 'rickydata/agent/node' for server usage.
@@ -26,6 +35,13 @@ export type {
   AgentDetailResponse,
   CustomAgentDefinition,
   CustomAgentUpsertResult,
+
+  // Agent Builder (recipe-driven provisioning)
+  AgentSpec,
+  AgentRecipe,
+  SkillFile,
+  CreateResult,
+  VerifyResult,
 
   // Chat
   ChatOptions,

--- a/packages/core/src/agent/recipe.ts
+++ b/packages/core/src/agent/recipe.ts
@@ -1,0 +1,206 @@
+/**
+ * Recipe parsing for the Agent Builder.
+ *
+ * Parses an `agent.md` document — YAML-ish front-matter plus a markdown body —
+ * into an {@link AgentSpec}. The format mirrors the agent definition front-matter
+ * documented in the create-flow contract (§3): simple `key: value` scalars,
+ * comma-separated OR inline/block YAML lists, and a nested `reflect:` block.
+ *
+ * A full YAML parser is intentionally avoided (no runtime dependency); the
+ * contract's front-matter only uses the small subset handled here.
+ */
+
+import type { AgentSpec, ReflectConfig } from './types.js';
+
+const FRONT_MATTER_RE = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/;
+
+export interface ParsedFrontMatter {
+  fields: Record<string, unknown>;
+  body: string;
+}
+
+/** Split an agent.md into its front-matter fields and markdown body. */
+export function splitFrontMatter(raw: string): ParsedFrontMatter {
+  const match = raw.match(FRONT_MATTER_RE);
+  if (!match) {
+    // No front-matter — treat the whole document as the body.
+    return { fields: {}, body: raw.trim() };
+  }
+  return { fields: parseFrontMatterBlock(match[1]), body: (match[2] ?? '').trim() };
+}
+
+/** Parse the inner YAML-ish block (between the `---` fences). */
+export function parseFrontMatterBlock(block: string): Record<string, unknown> {
+  const fields: Record<string, unknown> = {};
+  const lines = block.split(/\r?\n/);
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    i += 1;
+    if (!line.trim() || line.trim().startsWith('#')) continue;
+
+    const colon = line.indexOf(':');
+    if (colon === -1) continue;
+    // Top-level keys only (no indentation) start a new field.
+    if (/^\s/.test(line)) continue;
+
+    const key = line.slice(0, colon).trim();
+    const rest = line.slice(colon + 1).trim();
+
+    if (rest === '') {
+      // Could be a nested map or a block list. Peek at the indented region.
+      const indented: string[] = [];
+      while (i < lines.length && (/^\s+\S/.test(lines[i]) || lines[i].trim() === '')) {
+        if (lines[i].trim() !== '') indented.push(lines[i]);
+        i += 1;
+      }
+      const blockItems = indented
+        .filter((l) => l.trim().startsWith('- '))
+        .map((l) => stripQuotes(l.trim().slice(2).trim()));
+      if (blockItems.length > 0) {
+        fields[key] = blockItems;
+      } else if (indented.length > 0) {
+        fields[key] = parseFrontMatterBlock(indented.map((l) => l.replace(/^\s{2}/, '')).join('\n'));
+      } else {
+        fields[key] = '';
+      }
+      continue;
+    }
+
+    fields[key] = parseScalarOrInlineList(rest);
+  }
+
+  return fields;
+}
+
+function parseScalarOrInlineList(value: string): unknown {
+  // Inline YAML list: [a, b, c]
+  if (value.startsWith('[') && value.endsWith(']')) {
+    return value
+      .slice(1, -1)
+      .split(',')
+      .map((v) => stripQuotes(v.trim()))
+      .filter((v) => v.length > 0);
+  }
+  return stripQuotes(value);
+}
+
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/** Coerce a front-matter value into a string[] (comma-separated string or list). */
+export function toStringList(value: unknown): string[] {
+  if (value === undefined || value === null) return [];
+  if (Array.isArray(value)) return value.map((v) => String(v).trim()).filter(Boolean);
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((v) => v.trim())
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function toBool(value: unknown): boolean | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (typeof value === 'boolean') return value;
+  const s = String(value).trim().toLowerCase();
+  if (s === 'true' || s === 'yes' || s === '1') return true;
+  if (s === 'false' || s === 'no' || s === '0') return false;
+  return undefined;
+}
+
+function toNumber(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const n = Number(value);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+/**
+ * Parse a full `agent.md` (front-matter + body) into an {@link AgentSpec}.
+ *
+ * Front-matter keys recognised (per the create-flow contract):
+ *   name, description, title, model, category|categories,
+ *   mcp_servers, agent_secrets, skills, visibility|public, builtin_tools,
+ *   kb_tools, reflect (nested: enabled, minConfidence, autoShare, defaultSpace)
+ * The markdown body becomes `systemPrompt`.
+ */
+export function parseAgentMarkdown(raw: string): AgentSpec {
+  const { fields, body } = splitFrontMatter(raw);
+
+  const name = typeof fields.name === 'string' ? fields.name.trim() : '';
+  if (!name) {
+    throw new Error('agent.md front-matter must declare a non-empty `name`');
+  }
+
+  const visibilityRaw = (fields.visibility ?? fields.public) as unknown;
+  let visibility: 'private' | 'public' | undefined;
+  if (typeof visibilityRaw === 'string') {
+    const v = visibilityRaw.trim().toLowerCase();
+    if (v === 'public' || v === 'true') visibility = 'public';
+    else if (v === 'private' || v === 'false') visibility = 'private';
+  } else if (typeof visibilityRaw === 'boolean') {
+    visibility = visibilityRaw ? 'public' : 'private';
+  }
+
+  const reflectField = fields.reflect as Record<string, unknown> | undefined;
+  let reflect: AgentSpec['reflect'];
+  if (reflectField && typeof reflectField === 'object') {
+    const enabled = toBool(reflectField.enabled);
+    const config: Record<string, unknown> = {};
+    const minConfidence = toNumber(reflectField.minConfidence);
+    const autoShare = toBool(reflectField.autoShare);
+    const defaultSpace = reflectField.defaultSpace;
+    if (minConfidence !== undefined) config.minConfidence = minConfidence;
+    if (autoShare !== undefined) config.autoShare = autoShare;
+    if (typeof defaultSpace === 'string' && defaultSpace) config.defaultSpace = defaultSpace;
+    reflect = {
+      ...(enabled !== undefined ? { enabled } : {}),
+      ...(Object.keys(config).length ? { config: config as Partial<ReflectConfig> } : {}),
+    };
+    if (reflect.enabled === undefined && !reflect.config) reflect = undefined;
+  }
+
+  const spec: AgentSpec = {
+    name,
+    systemPrompt: body,
+  };
+
+  if (typeof fields.id === 'string' && fields.id.trim()) spec.id = fields.id.trim();
+  if (typeof fields.title === 'string' && fields.title) spec.title = fields.title;
+  if (typeof fields.description === 'string' && fields.description) spec.description = fields.description;
+  if (typeof fields.model === 'string' && fields.model) spec.model = fields.model;
+
+  const category = fields.category ?? fields.categories;
+  if (typeof category === 'string' && category) spec.category = category;
+  else if (Array.isArray(category) && category.length) spec.category = String(category[0]);
+
+  const mcpServers = toStringList(fields.mcp_servers ?? fields.mcpServers);
+  if (mcpServers.length) spec.mcpServers = mcpServers;
+
+  const builtinTools = toStringList(fields.builtin_tools ?? fields.builtinTools);
+  if (builtinTools.length) spec.builtinTools = builtinTools;
+
+  const agentSecrets = toStringList(fields.agent_secrets ?? fields.agentSecrets);
+  if (agentSecrets.length) spec.agentSecrets = agentSecrets;
+
+  const skills = toStringList(fields.skills);
+  if (skills.length) spec.skills = skills;
+
+  if (visibility) spec.visibility = visibility;
+
+  const kbTools = toBool(fields.kb_tools ?? fields.kbTools);
+  if (kbTools !== undefined) spec.kbTools = kbTools;
+
+  if (reflect) spec.reflect = reflect;
+
+  return spec;
+}

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -503,6 +503,43 @@ export interface CodexAuthStatus {
   needsMigration?: boolean;
 }
 
+/**
+ * Anthropic (Claude Code) OAuth credential bundle uploaded to the gateway vault.
+ *
+ * Mirrors the canonical `claudeAiOauth` credential shape that Claude Code itself
+ * persists (see `~/.claude/.credentials.json`), so the gateway can reuse standard
+ * Anthropic OAuth token-refresh logic. This is the SHARED CONTRACT with the gateway
+ * repo for `POST /wallet/anthropic-oauth`.
+ */
+export interface AnthropicOAuthBundle {
+  claudeAiOauth: {
+    /** OAuth access token (`sk-ant-oat...`). NEVER logged or written to disk in plaintext. */
+    accessToken: string;
+    /** OAuth refresh token (`sk-ant-ort...`). */
+    refreshToken: string;
+    /** Absolute expiry as epoch milliseconds. */
+    expiresAt: number;
+    /** Granted scopes, e.g. ['org:create_api_key','user:profile','user:inference','user:sessions:claude_code']. */
+    scopes: string[];
+    /** Subscription tier when known (e.g. 'pro', 'max'); omitted otherwise. */
+    subscriptionType?: string;
+  };
+}
+
+/** Wallet-scoped status of a stored Anthropic OAuth credential (no token text). */
+export interface AnthropicOAuthStatus {
+  configured: boolean;
+  hasTokens?: boolean;
+  scopes?: string[];
+  expiresAt?: number;
+  subscriptionType?: string;
+  updatedAt?: string;
+  encryptionMode?: 'sign-to-derive' | 'legacy-plaintext' | 'none' | string;
+  persistent?: boolean;
+  unlocked?: boolean;
+  needsMigration?: boolean;
+}
+
 // ─── Wallet ─────────────────────────────────────────────────
 
 export interface WalletSettings {

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -195,6 +195,107 @@ export interface KbToolsStatus {
   kbToolsEnabled: boolean;
 }
 
+// ─── Agent Builder (recipe-driven provisioning) ─────────────
+
+/**
+ * High-level spec for creating an agent programmatically. The builder maps this
+ * to a {@link CustomAgentDefinition} for `POST /agents/custom`, then runs the
+ * follow-up provisioning steps (skills, claude-md, secrets, kb-tools).
+ *
+ * `name`/`systemPrompt` are the only required fields; everything else is optional
+ * and mirrors the agent definition front-matter documented in the create-flow contract.
+ */
+export interface AgentSpec {
+  /** Slug/base name. Private agents get a `-<6hex>` suffix appended to form the id. */
+  name: string;
+  /** System prompt (the markdown body of an agent.md recipe). */
+  systemPrompt: string;
+  /** Pre-computed id. Defaults to `name` for a first create; the gateway may return a suffixed id. */
+  id?: string;
+  title?: string;
+  description?: string;
+  /** e.g. 'haiku' | 'sonnet' | 'opus' | a named variant. */
+  model?: string;
+  /** Category (JSON `category`, markdown `categories`). */
+  category?: string;
+  /** MCP server ids/names to attach. */
+  mcpServers?: string[];
+  /** Gateway builtin tool names. */
+  builtinTools?: string[];
+  /** Names of agent secrets the agent expects (values supplied separately at deploy time). */
+  agentSecrets?: string[];
+  /** Wallet skill names to upload (resolved to `skills/<name>.md` when deploying a recipe). */
+  skills?: string[];
+  /** 'private' (default) or 'public'. */
+  visibility?: 'private' | 'public';
+  /** Enable gateway-native KnowledgeBook (KFDB) tools after create. */
+  kbTools?: boolean;
+  /** Reflect/KnowledgeBook config to apply after create. */
+  reflect?: { enabled?: boolean; config?: Partial<ReflectConfig> };
+  /** Extra metadata stored on the definition. */
+  metadata?: Record<string, unknown>;
+}
+
+/** A single skill file parsed from a recipe's `skills/` directory. */
+export interface SkillFile {
+  /** Skill name (filename stem, minus the `.md` extension). */
+  name: string;
+  /** Full markdown content of the skill file. */
+  content: string;
+}
+
+/**
+ * A parsed recipe directory: the agent spec (from `agent.md` front-matter + body),
+ * its skill files, and optional per-agent CLAUDE routing.
+ */
+export interface AgentRecipe {
+  /** The agent spec derived from `agent.md`. */
+  spec: AgentSpec;
+  /** Skill files from `skills/*.md`. */
+  skills: SkillFile[];
+  /** Raw content of `claude-routing.md`, if present. */
+  claudeRouting?: string;
+}
+
+/** Result of a create / deploy run. Records each provisioning step that ran. */
+export interface CreateResult {
+  /** The agent id returned by the gateway (may carry a `-<6hex>` suffix). */
+  agentId: string;
+  agentName?: string;
+  qualityScore?: number;
+  /** Skill names successfully uploaded. */
+  uploadedSkills: string[];
+  /** Whether per-agent CLAUDE routing was uploaded. */
+  claudeRoutingUploaded: boolean;
+  /** Agent-secret names that were set. */
+  agentSecretsSet: string[];
+  /** MCP server ids that had secrets set. */
+  mcpSecretsSet: string[];
+  /** Whether KnowledgeBook tools were enabled. */
+  kbToolsEnabled: boolean;
+  /** Whether reflect config was applied. */
+  reflectConfigured: boolean;
+}
+
+/** Outcome of {@link AgentBuilder.verify}: the live state of a provisioned agent. */
+export interface VerifyResult {
+  agentId: string;
+  /** Whether `GET /agents/custom/{id}` returned the agent. */
+  exists: boolean;
+  /** Skill names reported by the wallet skills listing for this agent. */
+  skills: string[];
+  /** MCP tool names exposed via `tools/list` on the agent MCP endpoint. */
+  tools: string[];
+  /** Per-server secret requirements (from `/agents/{id}/mcp-requirements`). */
+  mcpRequirements?: McpRequirementsResponse;
+  /** Agent-level secret status. */
+  secretStatus?: AgentSecretStatus;
+  /** KnowledgeBook tools enabled flag. */
+  kbToolsEnabled?: boolean;
+  /** Reflect status (includes `kbAuthConfigured`). */
+  reflect?: ReflectStatus;
+}
+
 // ─── SSE Events (from Agent Gateway) ────────────────────────
 
 export interface SSETextEvent {

--- a/packages/core/src/cli/commands/agent.ts
+++ b/packages/core/src/cli/commands/agent.ts
@@ -1,0 +1,210 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import * as fs from 'fs/promises';
+import { AgentBuilder } from '../../agent/agent-builder.js';
+import { ConfigManager } from '../config/config-manager.js';
+import { CredentialStore } from '../config/credential-store.js';
+import { fail } from '../errors.js';
+
+function requireAuth(store: CredentialStore, profile: string): string {
+  const cred = store.getToken(profile);
+  if (!cred || !cred.token) {
+    fail('Not authenticated. Run `rickydata auth login` first.');
+  }
+  return cred.token;
+}
+
+/**
+ * Collect `--secret NAME=value` / `--mcp-secret SERVER:NAME=value` repeated
+ * flags into the maps deployRecipe expects. Values may also be loaded from a
+ * JSON file via `--secrets-file`.
+ */
+function parseSecretFlags(values: string[] | undefined): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const entry of values ?? []) {
+    const eq = entry.indexOf('=');
+    if (eq === -1) fail(`Invalid --secret "${entry}". Use NAME=value.`);
+    out[entry.slice(0, eq).trim()] = entry.slice(eq + 1);
+  }
+  return out;
+}
+
+function parseMcpSecretFlags(values: string[] | undefined): Record<string, Record<string, string>> {
+  const out: Record<string, Record<string, string>> = {};
+  for (const entry of values ?? []) {
+    const colon = entry.indexOf(':');
+    const eq = entry.indexOf('=');
+    if (colon === -1 || eq === -1 || eq < colon) {
+      fail(`Invalid --mcp-secret "${entry}". Use SERVER_ID:NAME=value.`);
+    }
+    const serverId = entry.slice(0, colon).trim();
+    const name = entry.slice(colon + 1, eq).trim();
+    const value = entry.slice(eq + 1);
+    (out[serverId] ??= {})[name] = value;
+  }
+  return out;
+}
+
+function collect(value: string, prev: string[]): string[] {
+  return [...prev, value];
+}
+
+/**
+ * Attach the agent-builder subcommands (create / deploy / verify) onto the
+ * existing `agents` command group, so they are reachable as
+ * `rickydata agent create|deploy|verify` (the group aliases `agent`).
+ * Listing is already provided by `agents list`.
+ */
+export function registerAgentBuilderCommands(
+  agent: Command,
+  config: ConfigManager,
+  store: CredentialStore,
+): Command {
+  // ─── create ───────────────────────────────────────────────
+  agent
+    .command('create')
+    .description('Create (or upsert) a custom agent from flags')
+    .requiredOption('--name <name>', 'Agent slug/base name')
+    .option('--prompt <text>', 'System prompt text')
+    .option('--prompt-file <path>', 'Read system prompt from a file')
+    .option('--title <title>', 'Agent title')
+    .option('--description <desc>', 'One-line description')
+    .option('--model <model>', 'Model (haiku|sonnet|opus|...)')
+    .option('--category <category>', 'Category')
+    .option('--mcp-server <id>', 'MCP server id/name to attach (repeatable)', collect, [])
+    .option('--kb-tools', 'Enable gateway-native KnowledgeBook (KFDB) tools', false)
+    .option('--json', 'Print the result as JSON', false)
+    .option('--profile <profile>', 'Config profile to use')
+    .option('--gateway <url>', 'Override agent gateway URL')
+    .action(async (opts) => {
+      const profile = opts.profile ?? config.getActiveProfile();
+      const gatewayUrl = (opts.gateway ?? config.getAgentGatewayUrl(profile)).replace(/\/$/, '');
+      const token = requireAuth(store, profile);
+
+      let systemPrompt = opts.prompt ?? '';
+      if (opts.promptFile) systemPrompt = await fs.readFile(opts.promptFile, 'utf8');
+      if (!systemPrompt.trim()) fail('A system prompt is required. Pass --prompt or --prompt-file.');
+
+      const builder = new AgentBuilder({ token, gatewayUrl });
+      const result = await builder.createAgent({
+        name: opts.name,
+        systemPrompt,
+        title: opts.title,
+        description: opts.description,
+        model: opts.model,
+        category: opts.category,
+        mcpServers: opts.mcpServer,
+        kbTools: opts.kbTools,
+      });
+
+      if (opts.kbTools) {
+        await builder.enableKbTools(result.agentId);
+        result.kbToolsEnabled = true;
+      }
+
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(chalk.green(`Created agent ${chalk.bold(result.agentId)}`));
+      if (result.qualityScore !== undefined) console.log(chalk.dim(`Quality score: ${result.qualityScore}`));
+      if (result.kbToolsEnabled) console.log(chalk.dim('KnowledgeBook tools: enabled'));
+    });
+
+  // ─── deploy ────────────────────────────────────────────────
+  agent
+    .command('deploy')
+    .description('Deploy an agent recipe directory (agent.md + skills/ + claude-routing.md)')
+    .argument('<dir>', 'Recipe directory')
+    .option('--secret <NAME=value>', 'Agent secret (repeatable)', collect, [])
+    .option('--mcp-secret <SERVER:NAME=value>', 'MCP-server secret (repeatable)', collect, [])
+    .option('--secrets-file <path>', 'JSON file of agent secrets ({ "NAME": "value" })')
+    .option('--kb-token <token>', 'Per-agent KFDB token (reflect/kb-token)')
+    .option('--skip-verify', 'Skip the post-deploy verify step', false)
+    .option('--json', 'Print the result as JSON', false)
+    .option('--profile <profile>', 'Config profile to use')
+    .option('--gateway <url>', 'Override agent gateway URL')
+    .action(async (dir, opts) => {
+      const profile = opts.profile ?? config.getActiveProfile();
+      const gatewayUrl = (opts.gateway ?? config.getAgentGatewayUrl(profile)).replace(/\/$/, '');
+      const token = requireAuth(store, profile);
+
+      const secrets = parseSecretFlags(opts.secret);
+      if (opts.secretsFile) {
+        const fileSecrets = JSON.parse(await fs.readFile(opts.secretsFile, 'utf8')) as Record<string, string>;
+        Object.assign(secrets, fileSecrets);
+      }
+      const mcpSecrets = parseMcpSecretFlags(opts.mcpSecret);
+
+      const builder = new AgentBuilder({ token, gatewayUrl });
+      const result = await builder.deployRecipe(dir, {
+        secrets,
+        mcpSecrets,
+        kbToken: opts.kbToken,
+        skipVerify: opts.skipVerify,
+        onStep: opts.json ? undefined : (step, detail) => {
+          process.stderr.write(chalk.dim(`  → ${step}${detail ? ` (${detail})` : ''}\n`));
+        },
+      });
+
+      if (opts.json) {
+        console.log(JSON.stringify(result, null, 2));
+        return;
+      }
+      console.log(chalk.green(`Deployed agent ${chalk.bold(result.agentId)}`));
+      if (result.uploadedSkills.length) console.log(chalk.dim(`Skills: ${result.uploadedSkills.join(', ')}`));
+      if (result.claudeRoutingUploaded) console.log(chalk.dim('CLAUDE routing: uploaded'));
+      if (result.agentSecretsSet.length) console.log(chalk.dim(`Agent secrets: ${result.agentSecretsSet.join(', ')}`));
+      if (result.mcpSecretsSet.length) console.log(chalk.dim(`MCP secrets: ${result.mcpSecretsSet.join(', ')}`));
+      if (result.kbToolsEnabled) console.log(chalk.dim('KnowledgeBook tools: enabled'));
+      if (result.reflectConfigured) console.log(chalk.dim('Reflect: configured'));
+    });
+
+  // ─── verify ────────────────────────────────────────────────
+  agent
+    .command('verify')
+    .description('Verify a provisioned agent (existence, skills, MCP tools, secrets, kb-tools)')
+    .argument('<agentId>', 'Agent id')
+    .option('--chat <message>', 'Also send a chat probe and print the response')
+    .option('--model <model>', 'Model for the chat probe')
+    .option('--json', 'Print the result as JSON', false)
+    .option('--profile <profile>', 'Config profile to use')
+    .option('--gateway <url>', 'Override agent gateway URL')
+    .action(async (agentId, opts) => {
+      const profile = opts.profile ?? config.getActiveProfile();
+      const gatewayUrl = (opts.gateway ?? config.getAgentGatewayUrl(profile)).replace(/\/$/, '');
+      const token = requireAuth(store, profile);
+
+      const builder = new AgentBuilder({ token, gatewayUrl });
+      const result = await builder.verify(agentId);
+
+      let chatResult: { text: string; toolCalls: string[] } | undefined;
+      if (opts.chat) {
+        const probe = await builder.chatProbe(agentId, opts.chat, { model: opts.model });
+        chatResult = { text: probe.text, toolCalls: probe.toolCalls };
+      }
+
+      if (opts.json) {
+        console.log(JSON.stringify({ ...result, chat: chatResult }, null, 2));
+        return;
+      }
+      console.log(`Agent ${chalk.bold(agentId)}: ${result.exists ? chalk.green('exists') : chalk.red('not found')}`);
+      console.log(chalk.dim(`Skills: ${result.skills.length ? result.skills.join(', ') : '(none)'}`));
+      console.log(chalk.dim(`MCP tools: ${result.tools.length ? result.tools.join(', ') : '(none)'}`));
+      if (result.secretStatus) {
+        console.log(chalk.dim(`Secrets ready: ${result.secretStatus.ready} (missing: ${result.secretStatus.missingRequired.join(', ') || 'none'})`));
+      }
+      if (result.kbToolsEnabled !== undefined) console.log(chalk.dim(`KnowledgeBook tools: ${result.kbToolsEnabled}`));
+      if (result.reflect) console.log(chalk.dim(`Reflect enabled: ${result.reflect.reflectEnabled} (kbAuthConfigured: ${result.reflect.kbAuthConfigured})`));
+      if (chatResult) {
+        console.log(chalk.bold('\nChat probe:'));
+        console.log(chatResult.text);
+        if (chatResult.toolCalls.length) console.log(chalk.dim(`Tool calls: ${chatResult.toolCalls.join(', ')}`));
+      }
+    });
+
+  // `list` is provided by the existing `agents list` subcommand (reachable as
+  // `rickydata agent list` via the group alias), so it is not redefined here.
+
+  return agent;
+}

--- a/packages/core/src/cli/commands/agents.ts
+++ b/packages/core/src/cli/commands/agents.ts
@@ -9,6 +9,7 @@ import { CredentialStore } from '../config/credential-store.js';
 import { AgentClient } from '../../agent/agent-client.js';
 import { formatOutput, formatJson, type OutputFormat } from '../output/formatter.js';
 import { CliError } from '../errors.js';
+import { registerAgentBuilderCommands } from './agent.js';
 
 interface SkillInfo {
   name: string;
@@ -510,6 +511,9 @@ export function createAgentsCommands(config: ConfigManager, store: CredentialSto
         });
       }
     });
+
+  // Builder subcommands: rickydata agent create|deploy|verify
+  registerAgentBuilderCommands(agents, config, store);
 
   return agents;
 }

--- a/packages/core/src/cli/commands/claude.ts
+++ b/packages/core/src/cli/commands/claude.ts
@@ -1,0 +1,344 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import * as crypto from 'crypto';
+import * as http from 'http';
+import * as readline from 'readline';
+import { AddressInfo } from 'net';
+import { AgentClient } from '../../agent/agent-client.js';
+import type { AnthropicOAuthBundle } from '../../agent/types.js';
+import { ConfigManager } from '../config/config-manager.js';
+import { CredentialStore } from '../config/credential-store.js';
+import { CliError, fail } from '../errors.js';
+
+// ─── Verified OAuth constants (from claude-code v2.1.x `claude /login`) ───────
+// CLIENT_ID, scopes, authorize/token/redirect URLs all mirror the live flow so
+// Anthropic's IdP honors the request. Confirm against `claude /login` if these drift.
+const CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const AUTHORIZE_URL_CLAUDE = 'https://claude.ai/oauth/authorize';
+const AUTHORIZE_URL_CONSOLE = 'https://console.anthropic.com/oauth/authorize';
+const TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+const MANUAL_REDIRECT_URL = 'https://console.anthropic.com/oauth/code/callback';
+const SCOPES = ['org:create_api_key', 'user:profile', 'user:inference', 'user:sessions:claude_code'];
+
+function requireAuth(store: CredentialStore, profile: string): string {
+  const cred = store.getToken(profile);
+  if (!cred) {
+    fail('Not authenticated. Run `rickydata auth login` first.');
+  }
+  return cred.token;
+}
+
+function makeClient(config: ConfigManager, store: CredentialStore, opts: { profile?: string; gateway?: string }): AgentClient {
+  const profile = opts.profile ?? config.getActiveProfile();
+  const gatewayUrl = (opts.gateway ?? config.getAgentGatewayUrl(profile)).replace(/\/$/, '');
+  const token = requireAuth(store, profile);
+  const privateKey = store.getPrivateKey(profile) ?? undefined;
+  return new AgentClient({ token, privateKey, gatewayUrl });
+}
+
+// ─── PKCE helpers ─────────────────────────────────────────────────────────────
+
+export function base64url(buf: Buffer): string {
+  return buf.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+export function generatePkce(): { verifier: string; challenge: string } {
+  const verifier = base64url(crypto.randomBytes(32));
+  const challenge = base64url(crypto.createHash('sha256').update(verifier).digest());
+  return { verifier, challenge };
+}
+
+export function buildAuthorizeUrl(opts: {
+  base: string;
+  redirectUri: string;
+  challenge: string;
+  state: string;
+}): string {
+  const url = new URL(opts.base);
+  url.searchParams.set('code', 'true');
+  url.searchParams.set('client_id', CLIENT_ID);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('redirect_uri', opts.redirectUri);
+  url.searchParams.set('scope', SCOPES.join(' '));
+  url.searchParams.set('code_challenge', opts.challenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', opts.state);
+  return url.toString();
+}
+
+async function tryOpenBrowser(url: string): Promise<void> {
+  try {
+    const { default: open } = await import('open');
+    await open(url);
+  } catch {
+    // Best-effort only; the URL is always printed for manual navigation.
+  }
+}
+
+interface CapturedCode {
+  code: string;
+  state: string;
+}
+
+/**
+ * Capture the authorization code via a loopback HTTP listener on an ephemeral
+ * port (RFC 8252). Anthropic's IdP honors dynamic `http://localhost:<port>/callback`
+ * redirects, matching how `claude /login` itself works.
+ */
+async function captureViaLoopback(opts: {
+  base: string;
+  challenge: string;
+  state: string;
+}): Promise<{ captured: CapturedCode; redirectUri: string }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer();
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      server.close();
+      fn();
+    };
+
+    server.on('error', (err) => finish(() => reject(err)));
+
+    server.listen(0, '127.0.0.1', async () => {
+      const { port } = server.address() as AddressInfo;
+      const redirectUri = `http://localhost:${port}/callback`;
+      const authorizeUrl = buildAuthorizeUrl({ base: opts.base, redirectUri, challenge: opts.challenge, state: opts.state });
+
+      server.on('request', (req, res) => {
+        const reqUrl = new URL(req.url ?? '/', redirectUri);
+        if (reqUrl.pathname !== '/callback') {
+          res.writeHead(404).end();
+          return;
+        }
+        const code = reqUrl.searchParams.get('code');
+        const returnedState = reqUrl.searchParams.get('state');
+        const errParam = reqUrl.searchParams.get('error');
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        if (errParam) {
+          res.end('<html><body><h2>Authorization failed.</h2><p>You can close this tab and return to the terminal.</p></body></html>');
+          finish(() => reject(new Error(`Authorization denied: ${errParam}`)));
+          return;
+        }
+        if (!code || !returnedState) {
+          res.end('<html><body><h2>Missing authorization code.</h2><p>You can close this tab and return to the terminal.</p></body></html>');
+          finish(() => reject(new Error('Loopback callback missing code or state.')));
+          return;
+        }
+        res.end('<html><body><h2>Authorization complete.</h2><p>You can close this tab and return to the terminal.</p></body></html>');
+        finish(() => resolve({ captured: { code, state: returnedState }, redirectUri }));
+      });
+
+      console.log('\nOpen this URL to authorize RickyData with your Claude account:\n');
+      console.log(chalk.cyan(authorizeUrl));
+      console.log(chalk.dim('\nWaiting for authorization (listening on the loopback callback)…'));
+      await tryOpenBrowser(authorizeUrl);
+    });
+  });
+}
+
+/**
+ * Manual paste fallback: the IdP redirects to the registered console callback,
+ * which displays a `code#state` string for the user to paste back.
+ */
+async function captureViaPaste(opts: {
+  base: string;
+  challenge: string;
+  state: string;
+}): Promise<{ captured: CapturedCode; redirectUri: string }> {
+  const redirectUri = MANUAL_REDIRECT_URL;
+  const authorizeUrl = buildAuthorizeUrl({ base: opts.base, redirectUri, challenge: opts.challenge, state: opts.state });
+
+  console.log('\nOpen this URL to authorize RickyData with your Claude account:\n');
+  console.log(chalk.cyan(authorizeUrl));
+  console.log(chalk.dim('\nAfter approving, copy the code shown on the page (format: code#state).'));
+  await tryOpenBrowser(authorizeUrl);
+
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    fail('A TTY is required to paste the authorization code. Re-run interactively.');
+  }
+
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  const pasted = await new Promise<string>((resolve) => {
+    rl.question('\nPaste the authorization code: ', (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+
+  const [code, returnedState] = pasted.split('#');
+  if (!code || !returnedState) {
+    fail('Invalid code. Expected the full `code#state` string shown after authorization.');
+  }
+  return { captured: { code, state: returnedState }, redirectUri };
+}
+
+export interface TokenResponse {
+  access_token: string;
+  refresh_token: string;
+  expires_in?: number;
+  scope?: string;
+  token_type?: string;
+  account?: { subscription_type?: string };
+}
+
+async function exchangeCode(opts: {
+  code: string;
+  state: string;
+  verifier: string;
+  redirectUri: string;
+}): Promise<TokenResponse> {
+  const res = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      grant_type: 'authorization_code',
+      code: opts.code,
+      redirect_uri: opts.redirectUri,
+      client_id: CLIENT_ID,
+      code_verifier: opts.verifier,
+      state: opts.state,
+    }),
+  });
+  if (!res.ok) {
+    // Never echo the response body verbatim — it may contain token material on
+    // some IdP error paths. Surface only the status.
+    if (res.status === 401 || res.status === 400) {
+      throw new Error('Token exchange failed: the authorization code was invalid or expired. Re-run `rickydata claude sync`.');
+    }
+    throw new Error(`Token exchange failed: HTTP ${res.status}.`);
+  }
+  const data = (await res.json()) as TokenResponse;
+  if (!data.access_token || !data.refresh_token) {
+    throw new Error('Token exchange returned an unexpected response (no tokens).');
+  }
+  return data;
+}
+
+export function buildBundle(tokens: TokenResponse, nowMs: number): AnthropicOAuthBundle {
+  const scopes = (tokens.scope ?? '').split(' ').filter(Boolean);
+  return {
+    claudeAiOauth: {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token,
+      expiresAt: nowMs + (tokens.expires_in ?? 3600) * 1000,
+      scopes: scopes.length ? scopes : SCOPES,
+      ...(tokens.account?.subscription_type ? { subscriptionType: tokens.account.subscription_type } : {}),
+    },
+  };
+}
+
+export function createClaudeCommands(config: ConfigManager, store: CredentialStore): Command {
+  const claude = new Command('claude').description('Manage Claude (Anthropic) OAuth subscription auth for RickyData execution');
+
+  claude
+    .command('status')
+    .description('Check synced Claude OAuth subscription auth status')
+    .option('--profile <profile>', 'Config profile to use')
+    .option('--gateway <url>', 'Override agent gateway URL')
+    .action(async (opts) => {
+      try {
+        const client = makeClient(config, store, opts);
+        const remote = await client.getAnthropicOAuthStatus();
+        console.log(`Remote: ${remote.configured ? chalk.green('Configured') : chalk.yellow('Not configured')}`);
+        if (remote.configured) {
+          console.log(chalk.dim(`Tokens present: ${remote.hasTokens ? 'yes' : 'no'}`));
+          if (remote.scopes?.length) console.log(chalk.dim(`Scopes: ${remote.scopes.join(' ')}`));
+          if (remote.subscriptionType) console.log(chalk.dim(`Subscription: ${remote.subscriptionType}`));
+          if (remote.expiresAt) console.log(chalk.dim(`Access token expires: ${new Date(remote.expiresAt).toISOString()}`));
+          if (remote.encryptionMode) console.log(chalk.dim(`Encryption: ${remote.encryptionMode}`));
+          if (remote.unlocked !== undefined) console.log(chalk.dim(`Unlocked: ${remote.unlocked ? 'yes' : 'no'}`));
+          if (remote.needsMigration) console.log(chalk.yellow('Remote credential needs migration. Run `rickydata claude sync`.'));
+          if (remote.updatedAt) console.log(chalk.dim(`Updated: ${remote.updatedAt}`));
+        }
+      } catch (err) {
+        throw new CliError(err instanceof Error ? err.message : String(err));
+      }
+    });
+
+  claude
+    .command('sync')
+    .description('Run the Claude OAuth login and upload the credential for subscription-backed Claude execution')
+    .option('--paste', 'Use the paste-the-code flow instead of the loopback listener')
+    .option('--console', 'Authorize via console.anthropic.com (Console/API account) instead of claude.ai')
+    .option('--profile <profile>', 'Config profile to use')
+    .option('--gateway <url>', 'Override agent gateway URL')
+    .action(async (opts) => {
+      try {
+        // Construct the client first so auth/signing problems surface before login.
+        const client = makeClient(config, store, opts);
+        const base = opts.console ? AUTHORIZE_URL_CONSOLE : AUTHORIZE_URL_CLAUDE;
+        const { verifier, challenge } = generatePkce();
+        const state = base64url(crypto.randomBytes(32));
+
+        let result: { captured: CapturedCode; redirectUri: string };
+        if (opts.paste) {
+          result = await captureViaPaste({ base, challenge, state });
+        } else {
+          try {
+            result = await captureViaLoopback({ base, challenge, state });
+          } catch (loopbackErr) {
+            console.log(chalk.yellow(`\nLoopback capture unavailable (${loopbackErr instanceof Error ? loopbackErr.message : 'error'}). Falling back to paste flow.`));
+            result = await captureViaPaste({ base, challenge, state });
+          }
+        }
+
+        if (result.captured.state !== state) {
+          fail('State mismatch — the authorization response did not match this request. Aborting for safety.');
+        }
+
+        const tokens = await exchangeCode({
+          code: result.captured.code,
+          state,
+          verifier,
+          redirectUri: result.redirectUri,
+        });
+        // Stamp expiry here; Date.now is intentionally read at the call site (not in pure helpers).
+        const bundle = buildBundle(tokens, Date.now());
+
+        const status = await client.setAnthropicOAuth(bundle);
+        console.log(chalk.green('\nClaude OAuth credential encrypted and synced.'));
+        console.log(chalk.dim(`Remote status: ${status.configured ? 'configured' : 'not configured'}`));
+        if (status.scopes?.length) console.log(chalk.dim(`Scopes: ${status.scopes.join(' ')}`));
+        if (status.encryptionMode) console.log(chalk.dim(`Encryption: ${status.encryptionMode}`));
+        if (status.unlocked !== undefined) console.log(chalk.dim(`Unlocked: ${status.unlocked ? 'yes' : 'no'}`));
+      } catch (err) {
+        throw new CliError(err instanceof Error ? err.message : String(err));
+      }
+    });
+
+  claude
+    .command('unlock')
+    .description('Unlock encrypted Claude OAuth credential for the current gateway session')
+    .option('--profile <profile>', 'Config profile to use')
+    .option('--gateway <url>', 'Override agent gateway URL')
+    .action(async (opts) => {
+      try {
+        const client = makeClient(config, store, opts);
+        const status = await client.unlockAnthropicOAuth();
+        console.log(chalk.green('Claude OAuth credential unlocked.'));
+        if (status.encryptionMode) console.log(chalk.dim(`Encryption: ${status.encryptionMode}`));
+      } catch (err) {
+        throw new CliError(err instanceof Error ? err.message : String(err));
+      }
+    });
+
+  claude
+    .command('delete')
+    .description('Delete synced Claude OAuth credential from the gateway')
+    .option('--profile <profile>', 'Config profile to use')
+    .option('--gateway <url>', 'Override agent gateway URL')
+    .action(async (opts) => {
+      try {
+        const client = makeClient(config, store, opts);
+        await client.deleteAnthropicOAuth();
+        console.log(chalk.green('Claude OAuth credential deleted.'));
+      } catch (err) {
+        throw new CliError(err instanceof Error ? err.message : String(err));
+      }
+    });
+
+  return claude;
+}

--- a/packages/core/src/cli/index.ts
+++ b/packages/core/src/cli/index.ts
@@ -10,6 +10,7 @@ import { createSessionsCommands } from './commands/sessions.js';
 import { createWalletCommands } from './commands/wallet.js';
 import { createApiKeyCommands } from './commands/apikey.js';
 import { createCodexCommands } from './commands/codex.js';
+import { createClaudeCommands } from './commands/claude.js';
 import { createMcpCommands } from './commands/mcp.js';
 import { createCanvasCommands } from './commands/canvas.js';
 import { createGitHubCommands } from './commands/github.js';
@@ -41,6 +42,7 @@ export function createProgram(configManager?: ConfigManager, credentialStore?: C
   program.addCommand(createWalletCommands(config, store));
   program.addCommand(createApiKeyCommands(config, store));
   program.addCommand(createCodexCommands(config, store));
+  program.addCommand(createClaudeCommands(config, store));
   program.addCommand(createMcpCommands(config, store));
   program.addCommand(createCanvasCommands(config, store));
   program.addCommand(createGitHubCommands(config, store));

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -253,6 +253,26 @@ export { AgentClient } from './agent/index.js';
 // SessionStore removed from main export — uses Node.js builtins (fs, path, os)
 // Use: import { SessionStore } from 'rickydata/agent/session-store' for server
 
+// Agent Builder (recipe-driven provisioning) + recipe parsing helpers
+export {
+  AgentBuilder,
+  challengeVerifyToken,
+  parseAgentMarkdown,
+  splitFrontMatter,
+  parseFrontMatterBlock,
+  toStringList,
+} from './agent/index.js';
+export type {
+  AgentBuilderConfig,
+  DeployRecipeOptions,
+  ParsedFrontMatter,
+  AgentSpec,
+  AgentRecipe,
+  SkillFile,
+  CreateResult,
+  VerifyResult,
+} from './agent/index.js';
+
 // Agent Error Taxonomy
 export { AgentError, AgentErrorCode } from './agent/index.js';
 export type { AgentErrorContext } from './agent/index.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -325,6 +325,8 @@ export type {
   McpRequirementsResponse,
   AgentSecretStatus,
   CodexAuthStatus,
+  AnthropicOAuthStatus,
+  AnthropicOAuthBundle,
   // Wallet
   WalletSettings,
   WalletBalanceResponse,

--- a/packages/core/tests/agent-builder.test.ts
+++ b/packages/core/tests/agent-builder.test.ts
@@ -1,0 +1,336 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { AgentBuilder } from '../src/agent/agent-builder.js';
+import { AgentClient } from '../src/agent/agent-client.js';
+
+const GATEWAY = 'https://agents.rickydata.org';
+const TOKEN = 'mcpwt_test_token';
+
+/** Build a client + builder that uses a static token (no challenge/verify). */
+function makeBuilder() {
+  const client = new AgentClient({ token: TOKEN, gatewayUrl: GATEWAY, sessionStorePath: null });
+  const builder = new AgentBuilder({ token: TOKEN, gatewayUrl: GATEWAY, client });
+  return builder;
+}
+
+/** A fetch mock that matches on URL substring + method and returns a JSON body. */
+type Route = { match: RegExp; method?: string; status?: number; json?: unknown; text?: string };
+
+function routeFetch(routes: Route[]) {
+  const calls: { url: string; method: string; body?: unknown }[] = [];
+  const spy = vi.spyOn(globalThis, 'fetch').mockImplementation(async (input, init) => {
+    const url = String(input);
+    const method = (init?.method ?? 'GET').toUpperCase();
+    let body: unknown;
+    if (init?.body) {
+      try { body = JSON.parse(init.body as string); } catch { body = init.body; }
+    }
+    calls.push({ url, method, body });
+    const route = routes.find((r) => r.match.test(url) && (!r.method || r.method === method));
+    if (!route) {
+      throw new Error(`Unexpected fetch: ${method} ${url}`);
+    }
+    return {
+      ok: (route.status ?? 200) < 400,
+      status: route.status ?? 200,
+      json: () => Promise.resolve(route.json ?? {}),
+      text: () => Promise.resolve(route.text ?? JSON.stringify(route.json ?? {})),
+    } as Response;
+  });
+  return { calls, spy };
+}
+
+describe('AgentBuilder', () => {
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  describe('toDefinition', () => {
+    it('maps a spec to a CustomAgentDefinition', () => {
+      const def = AgentBuilder.toDefinition({
+        name: 'notes-qa',
+        systemPrompt: 'You are a notes agent.',
+        model: 'sonnet',
+        category: 'productivity',
+        mcpServers: ['srv-1'],
+        agentSecrets: ['KFDB_API_KEY'],
+        skills: ['a', 'b'],
+        visibility: 'private',
+      });
+      expect(def.id).toBe('notes-qa');
+      expect(def.name).toBe('notes-qa');
+      expect(def.model).toBe('sonnet');
+      expect(def.category).toBe('productivity');
+      expect(def.mcp_servers).toEqual(['srv-1']);
+      expect(def.systemPrompt).toBe('You are a notes agent.');
+      expect(def.metadata).toMatchObject({
+        agent_secrets: ['KFDB_API_KEY'],
+        skills: ['a', 'b'],
+        visibility: 'private',
+      });
+    });
+
+    it('requires a name', () => {
+      expect(() => AgentBuilder.toDefinition({ name: '', systemPrompt: 'x' })).toThrow(/name/);
+    });
+  });
+
+  describe('createAgent', () => {
+    it('POSTs /agents/custom with { definition }', async () => {
+      const { calls } = routeFetch([
+        { match: /\/agents\/custom$/, method: 'POST', json: { agentId: 'notes-qa-abc123', qualityScore: 80 } },
+      ]);
+      const builder = makeBuilder();
+      const result = await builder.createAgent({ name: 'notes-qa', systemPrompt: 'You are a notes agent.' });
+
+      expect(result.agentId).toBe('notes-qa-abc123');
+      expect(result.qualityScore).toBe(80);
+      const post = calls.find((c) => c.method === 'POST' && /\/agents\/custom$/.test(c.url))!;
+      expect(post).toBeDefined();
+      expect(post.body).toHaveProperty('definition');
+      expect((post.body as { definition: { id: string } }).definition.id).toBe('notes-qa');
+    });
+  });
+
+  describe('uploadSkills', () => {
+    it('PUTs each skill to /wallet/skills/{name} with { content, agentId }', async () => {
+      const { calls } = routeFetch([
+        { match: /\/wallet\/skills\//, method: 'PUT', json: {} },
+      ]);
+      const builder = makeBuilder();
+      const uploaded = await builder.uploadSkills('notes-qa-abc123', [
+        { name: 'kfdb-sql-patterns', content: '# SQL' },
+        { name: 'kfdb-schema-map', content: '# Schema' },
+      ]);
+
+      expect(uploaded).toEqual(['kfdb-sql-patterns', 'kfdb-schema-map']);
+      expect(calls).toHaveLength(2);
+      expect(calls[0].url).toBe(`${GATEWAY}/wallet/skills/kfdb-sql-patterns`);
+      expect(calls[0].method).toBe('PUT');
+      expect(calls[0].body).toEqual({ content: '# SQL', agentId: 'notes-qa-abc123' });
+      expect(calls[1].url).toBe(`${GATEWAY}/wallet/skills/kfdb-schema-map`);
+    });
+
+    it('throws with the gateway error body on a non-2xx', async () => {
+      routeFetch([{ match: /\/wallet\/skills\//, method: 'PUT', status: 403, text: 'forbidden' }]);
+      const builder = makeBuilder();
+      await expect(
+        builder.uploadSkills('id', [{ name: 's', content: 'c' }]),
+      ).rejects.toThrow(/Failed to upload skill "s": 403 forbidden/);
+    });
+  });
+
+  describe('uploadClaudeRouting', () => {
+    it('PUTs /wallet/claude-md/{id} with { content }', async () => {
+      const { calls } = routeFetch([{ match: /\/wallet\/claude-md\//, method: 'PUT', json: {} }]);
+      const builder = makeBuilder();
+      await builder.uploadClaudeRouting('notes-qa-abc123', '# routing');
+      expect(calls[0].url).toBe(`${GATEWAY}/wallet/claude-md/notes-qa-abc123`);
+      expect(calls[0].method).toBe('PUT');
+      expect(calls[0].body).toEqual({ content: '# routing' });
+    });
+  });
+
+  describe('setAgentSecrets', () => {
+    it('POSTs /wallet/agent-secrets/{id} with { secrets }', async () => {
+      const { calls } = routeFetch([{ match: /\/wallet\/agent-secrets\//, method: 'POST', json: {} }]);
+      const builder = makeBuilder();
+      const names = await builder.setAgentSecrets('id', { KFDB_API_KEY: 'kf_xxx' });
+      expect(names).toEqual(['KFDB_API_KEY']);
+      expect(calls[0].url).toBe(`${GATEWAY}/wallet/agent-secrets/id`);
+      expect(calls[0].body).toEqual({ secrets: { KFDB_API_KEY: 'kf_xxx' } });
+    });
+
+    it('is a no-op for empty secrets', async () => {
+      const { calls } = routeFetch([]);
+      const builder = makeBuilder();
+      expect(await builder.setAgentSecrets('id', {})).toEqual([]);
+      expect(calls).toHaveLength(0);
+    });
+  });
+
+  describe('setMcpSecrets', () => {
+    it('POSTs /wallet/mcp-secrets/{serverId} with { secrets }', async () => {
+      const { calls } = routeFetch([{ match: /\/wallet\/mcp-secrets\//, method: 'POST', json: {} }]);
+      const builder = makeBuilder();
+      await builder.setMcpSecrets('srv-1', { X_API_KEY: 'v' });
+      expect(calls[0].url).toBe(`${GATEWAY}/wallet/mcp-secrets/srv-1`);
+      expect(calls[0].body).toEqual({ secrets: { X_API_KEY: 'v' } });
+    });
+  });
+
+  describe('enableKbTools', () => {
+    it('PUTs /agents/custom/{id}/kb-tools with { enabled: true }', async () => {
+      const { calls } = routeFetch([
+        { match: /\/agents\/custom\/.*\/kb-tools$/, method: 'PUT', json: { kbToolsEnabled: true } },
+      ]);
+      const builder = makeBuilder();
+      await builder.enableKbTools('notes-qa-abc123');
+      expect(calls[0].url).toBe(`${GATEWAY}/agents/custom/notes-qa-abc123/kb-tools`);
+      expect(calls[0].body).toEqual({ enabled: true });
+    });
+  });
+
+  describe('deploy', () => {
+    it('runs create → skills → claude-md → agent-secrets → mcp-secrets → kb-tools in order', async () => {
+      const { calls } = routeFetch([
+        { match: /\/agents\/custom$/, method: 'POST', json: { agentId: 'notes-qa-abc123' } },
+        { match: /\/wallet\/skills\//, method: 'PUT', json: {} },
+        { match: /\/wallet\/claude-md\//, method: 'PUT', json: {} },
+        { match: /\/wallet\/agent-secrets\//, method: 'POST', json: {} },
+        { match: /\/wallet\/mcp-secrets\//, method: 'POST', json: {} },
+        { match: /\/agents\/custom\/.*\/kb-tools$/, method: 'PUT', json: { kbToolsEnabled: true } },
+      ]);
+      const builder = makeBuilder();
+      const recipe = {
+        spec: {
+          name: 'notes-qa',
+          systemPrompt: 'You are a notes agent.',
+          model: 'sonnet',
+          skills: ['kfdb-sql-patterns'],
+          agentSecrets: ['KFDB_API_KEY'],
+          kbTools: true,
+        },
+        skills: [{ name: 'kfdb-sql-patterns', content: '# SQL' }],
+        claudeRouting: '# routing',
+      };
+      const result = await builder.deploy(recipe, {
+        secrets: { KFDB_API_KEY: 'kf_xxx' },
+        mcpSecrets: { 'srv-1': { X_API_KEY: 'v' } },
+        skipVerify: true,
+      });
+
+      expect(result.agentId).toBe('notes-qa-abc123');
+      expect(result.uploadedSkills).toEqual(['kfdb-sql-patterns']);
+      expect(result.claudeRoutingUploaded).toBe(true);
+      expect(result.agentSecretsSet).toEqual(['KFDB_API_KEY']);
+      expect(result.mcpSecretsSet).toEqual(['srv-1']);
+      expect(result.kbToolsEnabled).toBe(true);
+
+      // Endpoint ordering matches the create-flow contract §4.
+      const seq = calls.map((c) => `${c.method} ${c.url.replace(GATEWAY, '')}`);
+      expect(seq).toEqual([
+        'POST /agents/custom',
+        'PUT /wallet/skills/kfdb-sql-patterns',
+        'PUT /wallet/claude-md/notes-qa-abc123',
+        'POST /wallet/agent-secrets/notes-qa-abc123',
+        'POST /wallet/mcp-secrets/srv-1',
+        'PUT /agents/custom/notes-qa-abc123/kb-tools',
+      ]);
+
+      // Subsequent steps are keyed on the agentId returned by create (with suffix).
+      expect(calls[1].body).toMatchObject({ agentId: 'notes-qa-abc123' });
+    });
+  });
+
+  describe('deployRecipe (filesystem parsing)', () => {
+    let dir: string;
+    beforeEach(async () => {
+      dir = await fs.mkdtemp(path.join(os.tmpdir(), 'recipe-'));
+      await fs.writeFile(path.join(dir, 'agent.md'), [
+        '---',
+        'name: notes-qa',
+        'model: sonnet',
+        'public: false',
+        'kb_tools: true',
+        'agent_secrets: KFDB_API_KEY',
+        'skills: kfdb-sql-patterns,kfdb-schema-map',
+        '---',
+        '',
+        'You are a notes agent.',
+      ].join('\n'));
+      await fs.writeFile(path.join(dir, 'claude-routing.md'), '# routing');
+      // Skill-per-directory layout (matches the notes recipe).
+      await fs.mkdir(path.join(dir, 'skills', 'kfdb-sql-patterns'), { recursive: true });
+      await fs.writeFile(path.join(dir, 'skills', 'kfdb-sql-patterns', 'SKILL.md'), '# SQL patterns');
+      // Flat layout (fallback) for the second skill.
+      await fs.writeFile(path.join(dir, 'skills', 'kfdb-schema-map.md'), '# Schema map');
+    });
+    afterEach(async () => { await fs.rm(dir, { recursive: true, force: true }); });
+
+    it('parses both skill layouts and runs the full deploy sequence', async () => {
+      const { calls } = routeFetch([
+        { match: /\/agents\/custom$/, method: 'POST', json: { agentId: 'notes-qa-abc123' } },
+        { match: /\/wallet\/skills\//, method: 'PUT', json: {} },
+        { match: /\/wallet\/claude-md\//, method: 'PUT', json: {} },
+        { match: /\/wallet\/agent-secrets\//, method: 'POST', json: {} },
+        { match: /\/agents\/custom\/.*\/kb-tools$/, method: 'PUT', json: { kbToolsEnabled: true } },
+      ]);
+      const builder = makeBuilder();
+      const result = await builder.deployRecipe(dir, {
+        secrets: { KFDB_API_KEY: 'kf_xxx' },
+        skipVerify: true,
+      });
+
+      expect(result.uploadedSkills).toEqual(['kfdb-sql-patterns', 'kfdb-schema-map']);
+      expect(result.claudeRoutingUploaded).toBe(true);
+      expect(result.kbToolsEnabled).toBe(true);
+
+      const skillPuts = calls.filter((c) => /\/wallet\/skills\//.test(c.url));
+      expect(skillPuts[0].body).toEqual({ content: '# SQL patterns', agentId: 'notes-qa-abc123' });
+      expect(skillPuts[1].body).toEqual({ content: '# Schema map', agentId: 'notes-qa-abc123' });
+    });
+
+    it('parses the recipe without deploying via parseRecipe', async () => {
+      const recipe = await AgentBuilder.parseRecipe(dir);
+      expect(recipe.spec.name).toBe('notes-qa');
+      expect(recipe.spec.visibility).toBe('private');
+      expect(recipe.spec.kbTools).toBe(true);
+      expect(recipe.skills.map((s) => s.name)).toEqual(['kfdb-sql-patterns', 'kfdb-schema-map']);
+      expect(recipe.claudeRouting).toBe('# routing');
+    });
+
+    it('throws when a declared skill file is missing', async () => {
+      await fs.rm(path.join(dir, 'skills', 'kfdb-schema-map.md'));
+      await expect(AgentBuilder.parseRecipe(dir)).rejects.toThrow(/kfdb-schema-map/);
+    });
+  });
+
+  describe('verify', () => {
+    it('aggregates existence, MCP tools, requirements, secret + kb status (best-effort)', async () => {
+      const { calls } = routeFetch([
+        { match: /\/agents\/custom\/notes-qa-abc123$/, method: 'GET', json: { id: 'notes-qa-abc123' } },
+        { match: /\/wallet\/skills\/agent\//, method: 'GET', json: { skills: [{ name: 'kfdb-sql-patterns', source: 'wallet' }] } },
+        { match: /\/agents\/.*\/mcp$/, method: 'POST', text: 'data: {"jsonrpc":"2.0","id":1,"result":{"tools":[{"name":"execute_sql"},{"name":"semantic_search"}]}}\n\n' },
+        { match: /\/mcp-requirements$/, method: 'GET', json: { agentId: 'notes-qa-abc123', servers: [], totalRequired: 0 } },
+        { match: /\/wallet\/agent-secrets\//, method: 'GET', json: { configuredSecrets: ['KFDB_API_KEY'], missingRequired: [], ready: true } },
+        { match: /\/agents\/custom\/.*\/kb-tools$/, method: 'GET', json: { kbToolsEnabled: true } },
+        { match: /\/agents\/custom\/.*\/reflect$/, method: 'GET', json: { reflectEnabled: false, reflectConfig: { minConfidence: 0.6, autoShare: false, defaultSpace: 'general' }, kbAuthConfigured: true } },
+      ]);
+      const builder = makeBuilder();
+      const result = await builder.verify('notes-qa-abc123');
+
+      expect(result.exists).toBe(true);
+      expect(result.skills).toEqual(['kfdb-sql-patterns']);
+      expect(result.tools).toEqual(['execute_sql', 'semantic_search']);
+      expect(result.secretStatus?.ready).toBe(true);
+      expect(result.kbToolsEnabled).toBe(true);
+      expect(result.reflect?.kbAuthConfigured).toBe(true);
+      expect(calls.some((c) => /\/mcp-requirements$/.test(c.url))).toBe(true);
+    });
+
+    it('reports exists:false when the agent is not found, without throwing', async () => {
+      routeFetch([
+        { match: /\/agents\/custom\/missing$/, method: 'GET', status: 404, text: 'not found' },
+        { match: /\/wallet\/skills\/agent\//, method: 'GET', status: 404, text: 'nf' },
+        { match: /\/agents\/.*\/mcp$/, method: 'POST', status: 404, text: 'nf' },
+        { match: /\/mcp-requirements$/, method: 'GET', status: 404, text: 'nf' },
+        { match: /\/wallet\/agent-secrets\//, method: 'GET', status: 404, text: 'nf' },
+        { match: /\/kb-tools$/, method: 'GET', status: 404, text: 'nf' },
+        { match: /\/reflect$/, method: 'GET', status: 404, text: 'nf' },
+      ]);
+      const builder = makeBuilder();
+      const result = await builder.verify('missing');
+      expect(result.exists).toBe(false);
+      expect(result.skills).toEqual([]);
+      expect(result.tools).toEqual([]);
+    });
+  });
+
+  describe('constructor', () => {
+    it('requires a token, privateKey, or client', () => {
+      expect(() => new AgentBuilder({})).toThrow(/token, privateKey, or a pre-built client/);
+    });
+  });
+});

--- a/packages/core/tests/agent-client.test.ts
+++ b/packages/core/tests/agent-client.test.ts
@@ -1072,7 +1072,8 @@ describe('AgentClient — Anthropic OAuth (Claude Code subscription)', () => {
     const putCall = fetchSpy.mock.calls.find(([url, init]) => url === `${GATEWAY}/wallet/anthropic-oauth` && (init as RequestInit)?.method === 'PUT');
     expect(putCall).toBeDefined();
     const putBody = JSON.parse((putCall![1] as RequestInit).body as string);
-    expect(putBody.bundle).toEqual(bundle);
+    // SHARED CONTRACT: the gateway reads the bundle from `credentials`.
+    expect(putBody.credentials).toEqual(bundle);
     expect(putBody.nonce).toBe('oauth-nonce');
     expect(putBody.signature).toMatch(/^0x[0-9a-f]+$/i);
   });

--- a/packages/core/tests/agent-client.test.ts
+++ b/packages/core/tests/agent-client.test.ts
@@ -1036,3 +1036,96 @@ describe('AgentClient', () => {
     });
   });
 });
+
+describe('AgentClient — Anthropic OAuth (Claude Code subscription)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('uploads a credential bundle via a wallet-signed PUT', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    // derive-challenge
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ message: 'Sign Anthropic OAuth', nonce: 'oauth-nonce' }),
+    } as Response);
+    // PUT
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ configured: true, hasTokens: true, encryptionMode: 'sign-to-derive' }),
+    } as Response);
+
+    // privateKey path (CLI/Node) — viem signs the gateway-issued message.
+    const client = new AgentClient({ token: 'wallet-token', privateKey: PRIVATE_KEY, gatewayUrl: GATEWAY, sessionStorePath: null });
+
+    const bundle = {
+      claudeAiOauth: {
+        accessToken: 'sk-ant-oat-SECRET',
+        refreshToken: 'sk-ant-ort-SECRET',
+        expiresAt: 123,
+        scopes: ['user:inference'],
+      },
+    };
+    const status = await client.setAnthropicOAuth(bundle);
+
+    expect(status.configured).toBe(true);
+    const putCall = fetchSpy.mock.calls.find(([url, init]) => url === `${GATEWAY}/wallet/anthropic-oauth` && (init as RequestInit)?.method === 'PUT');
+    expect(putCall).toBeDefined();
+    const putBody = JSON.parse((putCall![1] as RequestInit).body as string);
+    expect(putBody.bundle).toEqual(bundle);
+    expect(putBody.nonce).toBe('oauth-nonce');
+    expect(putBody.signature).toMatch(/^0x[0-9a-f]+$/i);
+  });
+
+  it('reads status without signing', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ configured: true, hasTokens: true, scopes: ['user:profile'] }),
+    } as Response);
+
+    const client = new AgentClient({ token: 'wallet-token', gatewayUrl: GATEWAY, sessionStorePath: null });
+    const status = await client.getAnthropicOAuthStatus();
+
+    expect(status.configured).toBe(true);
+    expect(status.scopes).toEqual(['user:profile']);
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${GATEWAY}/wallet/anthropic-oauth/status`,
+      expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer wallet-token' }) }),
+    );
+  });
+
+  it('unlocks via a wallet-signed POST', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ message: 'Sign Anthropic OAuth', nonce: 'n' }),
+    } as Response);
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve({ configured: true, unlocked: true }),
+    } as Response);
+
+    const client = new AgentClient({ token: 'wallet-token', privateKey: PRIVATE_KEY, gatewayUrl: GATEWAY, sessionStorePath: null });
+    const status = await client.unlockAnthropicOAuth();
+
+    expect(status.unlocked).toBe(true);
+    const postCall = fetchSpy.mock.calls.find(([url]) => url === `${GATEWAY}/wallet/anthropic-oauth/unlock`);
+    expect(postCall).toBeDefined();
+    expect((postCall![1] as RequestInit).method).toBe('POST');
+    expect(JSON.parse((postCall![1] as RequestInit).body as string).signature).toMatch(/^0x[0-9a-f]+$/i);
+  });
+
+  it('deletes via DELETE', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    fetchSpy.mockResolvedValueOnce({ ok: true } as Response);
+
+    const client = new AgentClient({ token: 'wallet-token', gatewayUrl: GATEWAY, sessionStorePath: null });
+    await client.deleteAnthropicOAuth();
+
+    expect(fetchSpy).toHaveBeenCalledWith(
+      `${GATEWAY}/wallet/anthropic-oauth`,
+      expect.objectContaining({ method: 'DELETE' }),
+    );
+  });
+});

--- a/packages/core/tests/cli/claude-commands.test.ts
+++ b/packages/core/tests/cli/claude-commands.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import { ConfigManager } from '../../src/cli/config/config-manager.js';
+import { CredentialStore } from '../../src/cli/config/credential-store.js';
+import { createProgram } from '../../src/cli/index.js';
+import {
+  base64url,
+  generatePkce,
+  buildAuthorizeUrl,
+  buildBundle,
+} from '../../src/cli/commands/claude.js';
+
+// `open` would try to launch a real browser — stub it.
+vi.mock('open', () => ({ default: vi.fn().mockResolvedValue(undefined) }));
+// readline can't be spied in ESM — mock it and defer the answer to a runtime hook
+// the test installs on globalThis (so it can read the just-printed authorize URL).
+vi.mock('readline', () => ({
+  createInterface: () => ({
+    question: (_prompt: string, cb: (answer: string) => void) => {
+      cb((globalThis as Record<string, unknown>).__claudePasteAnswer
+        ? ((globalThis as Record<string, unknown>).__claudePasteAnswer as () => string)()
+        : '');
+    },
+    close: () => {},
+  }),
+}));
+// Wallet signing is exercised via the derive-challenge → sign → PUT path.
+vi.mock('viem/accounts', () => ({
+  privateKeyToAccount: () => ({
+    signMessage: async () => '0xmocksignature',
+    address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  }),
+}));
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'rickydata-claude-test-'));
+}
+
+describe('claude OAuth helpers', () => {
+  it('derives a PKCE S256 challenge that matches the verifier', () => {
+    const { verifier, challenge } = generatePkce();
+    const expected = base64url(crypto.createHash('sha256').update(verifier).digest());
+    expect(challenge).toBe(expected);
+    expect(challenge).not.toContain('=');
+    expect(challenge).not.toContain('+');
+    expect(challenge).not.toContain('/');
+  });
+
+  it('builds an authorize URL matching the live Claude Code flow', () => {
+    const url = new URL(buildAuthorizeUrl({
+      base: 'https://claude.ai/oauth/authorize',
+      redirectUri: 'http://localhost:51234/callback',
+      challenge: 'CHALLENGE',
+      state: 'STATE',
+    }));
+    expect(url.origin + url.pathname).toBe('https://claude.ai/oauth/authorize');
+    expect(url.searchParams.get('code')).toBe('true');
+    expect(url.searchParams.get('client_id')).toBe('9d1c250a-e61b-44d9-88ed-5944d1962f5e');
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('redirect_uri')).toBe('http://localhost:51234/callback');
+    expect(url.searchParams.get('scope')).toBe('org:create_api_key user:profile user:inference user:sessions:claude_code');
+    expect(url.searchParams.get('code_challenge')).toBe('CHALLENGE');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+    expect(url.searchParams.get('state')).toBe('STATE');
+  });
+
+  it('builds a canonical claudeAiOauth bundle and never leaks raw scope strings', () => {
+    const bundle = buildBundle({
+      access_token: 'sk-ant-oat-SECRET',
+      refresh_token: 'sk-ant-ort-SECRET',
+      expires_in: 3600,
+      scope: 'org:create_api_key user:profile',
+    }, 1_000_000);
+    expect(bundle.claudeAiOauth.accessToken).toBe('sk-ant-oat-SECRET');
+    expect(bundle.claudeAiOauth.refreshToken).toBe('sk-ant-ort-SECRET');
+    expect(bundle.claudeAiOauth.expiresAt).toBe(1_000_000 + 3600 * 1000);
+    expect(bundle.claudeAiOauth.scopes).toEqual(['org:create_api_key', 'user:profile']);
+  });
+
+  it('falls back to default scopes when token response omits scope', () => {
+    const bundle = buildBundle({ access_token: 'a', refresh_token: 'r' }, 0);
+    expect(bundle.claudeAiOauth.scopes).toEqual([
+      'org:create_api_key', 'user:profile', 'user:inference', 'user:sessions:claude_code',
+    ]);
+    expect(bundle.claudeAiOauth.expiresAt).toBe(3600 * 1000);
+  });
+});
+
+describe('claude commands', () => {
+  let tmpDir: string;
+  let config: ConfigManager;
+  let store: CredentialStore;
+
+  beforeEach(() => {
+    tmpDir = makeTempDir();
+    config = new ConfigManager(path.join(tmpDir, 'config.json'));
+    store = new CredentialStore(path.join(tmpDir, 'credentials.json'));
+    store.setToken('mcpwt_test', '0xtest');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  describe('claude status', () => {
+    it('shows configured status with scopes (no token text)', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ configured: true, hasTokens: true, scopes: ['user:inference'], encryptionMode: 'sign-to-derive', unlocked: true }),
+        text: async () => '',
+      } as Partial<Response>);
+      vi.stubGlobal('fetch', mockFetch);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const program = createProgram(config, store);
+      await program.parseAsync(['node', 'rickydata', 'claude', 'status']);
+
+      const call = mockFetch.mock.calls[0];
+      expect(call[0]).toContain('/wallet/anthropic-oauth/status');
+      const output = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(output).toContain('Configured');
+      expect(output).toContain('user:inference');
+      expect(output).not.toContain('0xtest');
+    });
+
+    it('shows not configured status', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ configured: false }),
+        text: async () => '',
+      } as Partial<Response>);
+      vi.stubGlobal('fetch', mockFetch);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const program = createProgram(config, store);
+      await program.parseAsync(['node', 'rickydata', 'claude', 'status']);
+
+      const output = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(output).toContain('Not configured');
+    });
+  });
+
+  describe('claude delete', () => {
+    it('sends DELETE to the anthropic-oauth endpoint', async () => {
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+        text: async () => '',
+      } as Partial<Response>);
+      vi.stubGlobal('fetch', mockFetch);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const program = createProgram(config, store);
+      await program.parseAsync(['node', 'rickydata', 'claude', 'delete']);
+
+      const call = mockFetch.mock.calls[0];
+      expect(call[1].method).toBe('DELETE');
+      expect(call[0]).toContain('/wallet/anthropic-oauth');
+      const output = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(output).toContain('deleted');
+    });
+  });
+
+  describe('claude unlock', () => {
+    it('signs a challenge and posts to the unlock endpoint', async () => {
+      store.setPrivateKey('0x' + 'a'.repeat(64));
+      const calls: Array<{ url: string; opts: RequestInit }> = [];
+      const mockFetch = vi.fn().mockImplementation(async (url: string, opts?: RequestInit) => {
+        calls.push({ url, opts: opts ?? {} });
+        if (url.includes('derive-challenge')) {
+          return { ok: true, json: async () => ({ message: 'Sign Anthropic OAuth', nonce: 'n-1' }), text: async () => '' };
+        }
+        return { ok: true, json: async () => ({ configured: true, encryptionMode: 'sign-to-derive', unlocked: true }), text: async () => '' };
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const program = createProgram(config, store);
+      await program.parseAsync(['node', 'rickydata', 'claude', 'unlock']);
+
+      expect(calls[0].url).toContain('/wallet/anthropic-oauth/derive-challenge');
+      const post = calls.find((c) => c.opts?.method === 'POST');
+      expect(post!.url).toContain('/wallet/anthropic-oauth/unlock');
+      const body = JSON.parse(post!.opts.body as string);
+      expect(body.signature).toBe('0xmocksignature');
+      const output = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(output).toContain('unlocked');
+    });
+  });
+
+  describe('claude sync --paste (end-to-end round trip)', () => {
+    it('exchanges the pasted code and uploads a wallet-signed bundle without printing tokens', async () => {
+      store.setPrivateKey('0x' + 'a'.repeat(64));
+      const origInTTY = process.stdin.isTTY;
+      const origOutTTY = process.stdout.isTTY;
+      (process.stdin as { isTTY?: boolean }).isTTY = true;
+      (process.stdout as { isTTY?: boolean }).isTTY = true;
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      // The mocked readline (top of file) calls this hook to produce the pasted
+      // value — we read the just-printed authorize URL and echo back `code#state`
+      // with the SAME state so the CSRF check passes.
+      (globalThis as Record<string, unknown>).__claudePasteAnswer = () => {
+        const printed = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+        const match = printed.match(/https:\/\/\S*oauth\/authorize\S+/);
+        const state = match ? new URL(match[0]).searchParams.get('state') : 'missing';
+        return `AUTH_CODE_123#${state}`;
+      };
+
+      const ACCESS = 'sk-ant-oat-SHOULD-NEVER-PRINT';
+      const REFRESH = 'sk-ant-ort-SHOULD-NEVER-PRINT';
+      const calls: Array<{ url: string; opts: RequestInit }> = [];
+      const mockFetch = vi.fn().mockImplementation(async (url: string, opts?: RequestInit) => {
+        calls.push({ url, opts: opts ?? {} });
+        if (url.includes('/v1/oauth/token')) {
+          return {
+            ok: true,
+            json: async () => ({ access_token: ACCESS, refresh_token: REFRESH, expires_in: 3600, scope: 'user:inference user:profile' }),
+            text: async () => '',
+          };
+        }
+        if (url.includes('derive-challenge')) {
+          return { ok: true, json: async () => ({ message: 'Sign Anthropic OAuth', nonce: 'n-1' }), text: async () => '' };
+        }
+        // PUT /wallet/anthropic-oauth
+        return { ok: true, json: async () => ({ configured: true, hasTokens: true, scopes: ['user:inference', 'user:profile'], encryptionMode: 'sign-to-derive', unlocked: true }), text: async () => '' };
+      });
+      vi.stubGlobal('fetch', mockFetch);
+
+      const program = createProgram(config, store);
+      await program.parseAsync(['node', 'rickydata', 'claude', 'sync', '--paste']);
+      (process.stdin as { isTTY?: boolean }).isTTY = origInTTY;
+      (process.stdout as { isTTY?: boolean }).isTTY = origOutTTY;
+
+      // 1. Token exchange used the correct endpoint, body, and manual redirect_uri.
+      const tokenCall = calls.find((c) => c.url.includes('/v1/oauth/token'));
+      expect(tokenCall).toBeDefined();
+      expect(tokenCall!.opts.method).toBe('POST');
+      const tokenBody = JSON.parse(tokenCall!.opts.body as string);
+      expect(tokenBody.grant_type).toBe('authorization_code');
+      expect(tokenBody.code).toBe('AUTH_CODE_123');
+      expect(tokenBody.client_id).toBe('9d1c250a-e61b-44d9-88ed-5944d1962f5e');
+      expect(tokenBody.redirect_uri).toBe('https://console.anthropic.com/oauth/code/callback');
+      expect(typeof tokenBody.code_verifier).toBe('string');
+
+      // 2. The bundle was uploaded via a wallet-signed PUT carrying the real tokens.
+      const putCall = calls.find((c) => c.opts?.method === 'PUT');
+      expect(putCall!.url).toContain('/wallet/anthropic-oauth');
+      const putBody = JSON.parse(putCall!.opts.body as string);
+      expect(putBody.signature).toBe('0xmocksignature');
+      expect(putBody.nonce).toBe('n-1');
+      expect(putBody.bundle.claudeAiOauth.accessToken).toBe(ACCESS);
+      expect(putBody.bundle.claudeAiOauth.refreshToken).toBe(REFRESH);
+
+      // 3. Tokens are NEVER printed to the console.
+      const output = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(output).toContain('synced');
+      expect(output).not.toContain(ACCESS);
+      expect(output).not.toContain(REFRESH);
+    });
+  });
+});

--- a/packages/core/tests/cli/claude-commands.test.ts
+++ b/packages/core/tests/cli/claude-commands.test.ts
@@ -254,8 +254,9 @@ describe('claude commands', () => {
       const putBody = JSON.parse(putCall!.opts.body as string);
       expect(putBody.signature).toBe('0xmocksignature');
       expect(putBody.nonce).toBe('n-1');
-      expect(putBody.bundle.claudeAiOauth.accessToken).toBe(ACCESS);
-      expect(putBody.bundle.claudeAiOauth.refreshToken).toBe(REFRESH);
+      // SHARED CONTRACT: the gateway reads the bundle from `credentials`.
+      expect(putBody.credentials.claudeAiOauth.accessToken).toBe(ACCESS);
+      expect(putBody.credentials.claudeAiOauth.refreshToken).toBe(REFRESH);
 
       // 3. Tokens are NEVER printed to the console.
       const output = consoleSpy.mock.calls.map((c) => c.join(' ')).join('\n');

--- a/packages/core/tests/recipe.test.ts
+++ b/packages/core/tests/recipe.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseAgentMarkdown,
+  splitFrontMatter,
+  parseFrontMatterBlock,
+  toStringList,
+} from '../src/agent/recipe.js';
+
+describe('recipe parsing', () => {
+  describe('splitFrontMatter', () => {
+    it('splits front-matter from body', () => {
+      const { fields, body } = splitFrontMatter('---\nname: foo\n---\nHello body');
+      expect(fields.name).toBe('foo');
+      expect(body).toBe('Hello body');
+    });
+
+    it('treats a document with no front-matter as all body', () => {
+      const { fields, body } = splitFrontMatter('Just a prompt, no fences');
+      expect(fields).toEqual({});
+      expect(body).toBe('Just a prompt, no fences');
+    });
+
+    it('handles CRLF line endings', () => {
+      const { fields, body } = splitFrontMatter('---\r\nname: foo\r\n---\r\nbody');
+      expect(fields.name).toBe('foo');
+      expect(body).toBe('body');
+    });
+  });
+
+  describe('parseFrontMatterBlock', () => {
+    it('parses scalars, comma lists, inline lists, and block lists', () => {
+      const fields = parseFrontMatterBlock([
+        'name: my-agent',
+        'model: sonnet',
+        'mcp_servers: a, b, c',
+        'inline: [x, y, z]',
+        'block:',
+        '  - one',
+        '  - two',
+      ].join('\n'));
+      expect(fields.name).toBe('my-agent');
+      expect(fields.model).toBe('sonnet');
+      expect(fields.mcp_servers).toBe('a, b, c');
+      expect(fields.inline).toEqual(['x', 'y', 'z']);
+      expect(fields.block).toEqual(['one', 'two']);
+    });
+
+    it('parses a nested map block (reflect)', () => {
+      const fields = parseFrontMatterBlock([
+        'reflect:',
+        '  enabled: true',
+        '  minConfidence: 0.6',
+        '  defaultSpace: notes',
+      ].join('\n'));
+      expect(fields.reflect).toEqual({
+        enabled: 'true',
+        minConfidence: '0.6',
+        defaultSpace: 'notes',
+      });
+    });
+
+    it('strips quotes from scalar values', () => {
+      const fields = parseFrontMatterBlock('description: "a quoted value"');
+      expect(fields.description).toBe('a quoted value');
+    });
+
+    it('ignores comment lines', () => {
+      const fields = parseFrontMatterBlock('# a comment\nname: x');
+      expect(fields.name).toBe('x');
+      expect(Object.keys(fields)).toEqual(['name']);
+    });
+  });
+
+  describe('toStringList', () => {
+    it('splits comma-separated strings', () => {
+      expect(toStringList('a, b ,c')).toEqual(['a', 'b', 'c']);
+    });
+    it('passes arrays through', () => {
+      expect(toStringList(['a', 'b'])).toEqual(['a', 'b']);
+    });
+    it('returns [] for empty/undefined', () => {
+      expect(toStringList(undefined)).toEqual([]);
+      expect(toStringList('')).toEqual([]);
+    });
+  });
+
+  describe('parseAgentMarkdown', () => {
+    const doc = [
+      '---',
+      'name: rickydata-notes-qa',
+      'description: Answers questions over your notes.',
+      'model: sonnet',
+      'public: false',
+      'categories: productivity',
+      'kb_tools: true',
+      'agent_secrets: KFDB_API_KEY',
+      'skills: kfdb-schema-map,kfdb-sql-patterns',
+      '---',
+      '',
+      '# rickydata-notes-qa',
+      '',
+      'You are a notes agent.',
+    ].join('\n');
+
+    it('maps the notes-agent front-matter to an AgentSpec', () => {
+      const spec = parseAgentMarkdown(doc);
+      expect(spec.name).toBe('rickydata-notes-qa');
+      expect(spec.description).toBe('Answers questions over your notes.');
+      expect(spec.model).toBe('sonnet');
+      expect(spec.category).toBe('productivity');
+      expect(spec.visibility).toBe('private'); // public: false → private
+      expect(spec.kbTools).toBe(true);
+      expect(spec.agentSecrets).toEqual(['KFDB_API_KEY']);
+      expect(spec.skills).toEqual(['kfdb-schema-map', 'kfdb-sql-patterns']);
+      expect(spec.systemPrompt).toContain('# rickydata-notes-qa');
+      expect(spec.systemPrompt).toContain('You are a notes agent.');
+      expect(spec.systemPrompt).not.toContain('name: rickydata-notes-qa');
+    });
+
+    it('throws when name is missing', () => {
+      expect(() => parseAgentMarkdown('---\nmodel: sonnet\n---\nbody')).toThrow(/name/);
+    });
+
+    it('maps public:true to visibility public', () => {
+      const spec = parseAgentMarkdown('---\nname: x\npublic: true\n---\nb');
+      expect(spec.visibility).toBe('public');
+    });
+
+    it('parses a reflect block into spec.reflect', () => {
+      const spec = parseAgentMarkdown([
+        '---',
+        'name: x',
+        'reflect:',
+        '  enabled: true',
+        '  minConfidence: 0.7',
+        '  autoShare: false',
+        '  defaultSpace: notes',
+        '---',
+        'body',
+      ].join('\n'));
+      expect(spec.reflect).toEqual({
+        enabled: true,
+        config: { minConfidence: 0.7, autoShare: false, defaultSpace: 'notes' },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Problem
`AgentClient.setAnthropicOAuth()` (used by `rickydata claude sync`) sent the Claude Code OAuth bundle under a `bundle` key. The deployed agent gateway reads it via `req.body?.credentials ?? req.body?.claudeAiOauth ?? req.body`, so `bundle` fell through to the whole request body, which has no top-level `accessToken` → `validateAnthropicOAuthBundle` rejects it. `rickydata claude sync` would always fail.

## Fix
Send the bundle under `credentials` (the shared contract key). Updated the two affected tests.

## Verification
- `packages/core` changed-area tests: **57 passed** (`agent-client.test.ts` + `cli/claude-commands.test.ts`)
- typecheck clean

Pairs with mcp_deployments_registry#333 (gateway side, deployed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)